### PR TITLE
Rewrite oplus

### DIFF
--- a/src/dynamics.F
+++ b/src/dynamics.F
@@ -341,7 +341,6 @@
      |  Fe    (levd0,lond0,latd0),
      |  Fn    (levd0,lond0,latd0),
      |  1,nlevp1,lon0,lon1,lat0,lat1)
-!
       if (debug) write(6,"('dynamics after oplus')")
       call timer(time0,time1,'OPLUS',1,0) ! end oplus timing
       if (timing%level >= 2.and.time2print(nstep,istep))

--- a/src/dynamics.F
+++ b/src/dynamics.F
@@ -19,7 +19,8 @@
 !          change call to qjoule_tn to include vertical velocity
 !
       use fields_module
-      use mpi_module,only: lon0,lon1,lat0,lat1,distribute_1d,mp_close
+      use mpi_module,only: lon0,lon1,lat0,lat1,distribute_1d,mp_close,
+     |  mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
       use chemrates_module,only: chemrates_tdep
       use qrj_module,only: qrj,qtotal,qop,qo2p,qn2p,qnp,qnop
       use chapman_module,only: chapman
@@ -51,7 +52,7 @@
 #endif
 !
 ! Local:
-      integer :: lat,ier,itp_sub,itc_sub,istep_sub,itmp
+      integer :: lat,ier
       integer :: i0,i1,nk,nkm1,nlats,k0,k1
       logical,parameter :: debug=.false.  ! add prints to stdout
 !
@@ -68,8 +69,6 @@
 !
       logical,parameter :: diags=.true. ! put fields on sec hist
       real :: time0,time1,time1_qrj,time1_cmpminor,time1_cmpmajor
-      real,dimension(levd0:levd1,lond0:lond1,latd0:latd1,2) ::
-     |  op_i,op_nm_i
       real,dimension(lon0:lon1,lat0:lat1) ::
      |  tec ! diagnostic total electron content
       logical,external :: time2print
@@ -304,47 +303,45 @@
 ! Full task subdomains (including ghost cells) are passed.
 !
       call timer(time0,time1,'OPLUS',0,0) ! start oplus timing
-      itp_sub = itp
-      itc_sub = itc
-      op_i = op
-      op_nm_i = op_nm
-! O+ sub-cycling, Dang, 2017
-      do istep_sub=1,nstep_sub
-        call oplus(
-     |    tn    (levd0,lond0,latd0,itp),
-     |    te    (levd0,lond0,latd0,itp),
-     |    ti    (levd0,lond0,latd0,itp),
-     |    o2    (levd0,lond0,latd0,itp),
-     |    o1    (levd0,lond0,latd0,itp),
-     |    he    (levd0,lond0,latd0,itp),
-     |    n2    (levd0,lond0,latd0),
-     |    n2d   (levd0,lond0,latd0,itp),
-     |    ne    (levd0,lond0,latd0,itp),
-     |    un    (levd0,lond0,latd0,itp),
-     |    vn    (levd0,lond0,latd0,itp),
-     |    w     (levd0,lond0,latd0,itp),
-     |    ui    (levd0,lond0,latd0),
-     |    vi    (levd0,lond0,latd0),
-     |    wi    (levd0,lond0,latd0),
-     |    xnmbar(levd0,lond0,latd0,itp),
-     |    scht  (levd0,lond0,latd0,itp),
-     |    op_i   (levd0,lond0,latd0,itp_sub),
-     |    op_nm_i(levd0,lond0,latd0,itp_sub),
-     |    op_i   (levd0,lond0,latd0,itc_sub), ! out
-     |    op_nm_i(levd0,lond0,latd0,itc_sub), ! out
-     |    xiop2p(levd0,lond0,latd0),          ! out
-     |    xiop2d(levd0,lond0,latd0),          ! out
-     |    Fe    (levd0,lond0,latd0),          ! out
-     |    Fn    (levd0,lond0,latd0),          ! out
-     |    1,nlevp1,lon0,lon1,lat0,lat1)
-        if (istep_sub /= nstep_sub) then
-          itmp = itp_sub
-          itp_sub = itc_sub
-          itc_sub = itmp
-        endif
-      enddo
-      op(:,:,:,itc) = op_i(:,:,:,itc_sub)
-      op_nm(:,:,:,itc) = op_nm_i(:,:,:,itc_sub)
+!
+! Make latitudes j=-1,0 from j=2,1, and j=nlat+1,nlat+2 from nlat-1,nlat for n2, 
+! then define 2d halos points.  Note that mp_geo_halos_f3d and mp_polelats_f3d 
+! do not define "outside corner" halo points, but this should be ok since 
+! cross-derivatives are not performed.
+!
+      call mp_polelats_f3d(n2(:,lon0:lon1,:),   ! 3rd dim is lat0-2:lat1+2
+     |  1,nlevp1,lon0,lon1,lat0,lat1,1,(/1./))  ! last arg means no change in polesign
+      call mp_bndlats_f3d(n2,nk,lon0,lon1,lat0,lat1,1)
+      call mp_bndlons_f3d(n2,nk,lon0,lon1,lat0,lat1,1,0)
+!
+      call oplus(
+     |  tn    (levd0,lond0,latd0,itp),
+     |  te    (levd0,lond0,latd0,itp),
+     |  ti    (levd0,lond0,latd0,itp),
+     |  o2    (levd0,lond0,latd0,itp),
+     |  o1    (levd0,lond0,latd0,itp),
+     |  he    (levd0,lond0,latd0,itp),
+     |  n2    (levd0,lond0,latd0),
+     |  n2d   (levd0,lond0,latd0,itp),
+     |  ne    (levd0,lond0,latd0,itp),
+     |  un    (levd0,lond0,latd0,itp),
+     |  vn    (levd0,lond0,latd0,itp),
+     |  w     (levd0,lond0,latd0,itp),
+     |  ui    (levd0,lond0,latd0),
+     |  vi    (levd0,lond0,latd0),
+     |  wi    (levd0,lond0,latd0),
+     |  xnmbar(levd0,lond0,latd0,itp),
+     |  scht  (levd0,lond0,latd0,itp),
+     |  op    (levd0,lond0,latd0,itp),
+     |  op_nm (levd0,lond0,latd0,itp),
+     |  op    (levd0,lond0,latd0,itc), ! out
+     |  op_nm (levd0,lond0,latd0,itc), ! out
+     |  xiop2p(levd0,lond0,latd0),     ! out
+     |  xiop2d(levd0,lond0,latd0),     ! out
+     |  Fe    (levd0,lond0,latd0),
+     |  Fn    (levd0,lond0,latd0),
+     |  1,nlevp1,lon0,lon1,lat0,lat1)
+!
       if (debug) write(6,"('dynamics after oplus')")
       call timer(time0,time1,'OPLUS',1,0) ! end oplus timing
       if (timing%level >= 2.and.time2print(nstep,istep))

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -259,7 +259,6 @@
      |  ppolar = 0.
       integer :: k,i,lat,lonbeg,lonend,nlevs
       real :: gmr,a,fed,fen,dbxdx,dbydy,tr,djmin,
-     |  o2_cm3,o1_cm3,n2_cm3,he_cm3,n2d_cm3,
      |  ubca, ubcb ! O+ upper boundary condition (were t2,t3)
       real,dimension(lev0:lev1) :: bdotu1
       real,dimension(lon0:lon1,lat0:lat1) ::
@@ -275,7 +274,8 @@
      |  hdzi,bdotdh_djbz,
      |  djint_tphdz0,djint_tphdz1,
      |  djint_tphdz0_1,djint_tphdz1_1
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) :: djbz
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
+     |  o2_cm3,o1_cm3,he_cm3,n2_cm3,n2d_cm3,djbz
       real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) :: tmpf3d
 !
 ! Number of pressure levels (this will equal nlevp1):
@@ -356,6 +356,18 @@
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
           do k=lev0,lev1-1
+            o2_cm3(k,i,lat) = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
+            o1_cm3(k,i,lat) = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
+            he_cm3(k,i,lat) = xnmbar(k,i,lat)*he(k,i,lat)*rmassinv_he
+            n2_cm3(k,i,lat) = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
+            n2d_cm3(k,i,lat) = xnmbar(k,i,lat)*n2d(k,i,lat)*rmassinv_n2d
+          enddo
+        enddo
+      enddo
+!
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
 !
 ! Set reduced temperature (average of tn and ti)
 !
@@ -368,15 +380,12 @@
 !   as a consequence of fixing this bug.
 !
             tr = 0.5*(tn(k,i,lat)+ti(k,i,lat))
-            o2_cm3 = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
-            o1_cm3 = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
-            he_cm3 = xnmbar(k,i,lat)*he(k,i,lat)*rmassinv_he
-            n2_cm3 = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
 !
 ! 8/28/13 btf: Use n2=1-o2-o-he, and include O+/He collision rate from Wenbin:
 !
-            dj(k,i,lat) = 1.42E17/(18.1*o2_cm3+3.6*he_cm3+18.6*n2_cm3+
-     |        o1_cm3*sqrt(tr)*(1.-0.064*log10(tr))**2*colfac)
+            dj(k,i,lat) = 1.42E17/(18.1*o2_cm3(k,i,lat)+
+     |        3.6*he_cm3(k,i,lat)+18.6*n2_cm3(k,i,lat)+
+     |        o1_cm3(k,i,lat)*sqrt(tr)*(1.-0.064*log10(tr))**2*colfac)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
@@ -712,24 +721,20 @@
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
-            o2_cm3 = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
-            o1_cm3 = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
-            n2_cm3 = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
-            n2d_cm3 = xnmbar(k,i,lat)*n2d(k,i,lat)*rmassinv_n2d
-!
             xiop2p(k,i,lat) =
      |        0.5*(qop2p(k,i,lat)+qop2p(k+1,i,lat))/
-     |        ((rk16+rk17)*n2_cm3+rk18*o1_cm3+
+     |        ((rk16+rk17)*n2_cm3(k,i,lat)+rk18*o1_cm3(k,i,lat)+
      |        (rk19(k,i,lat)+rk20(k,i,lat))*ne(k,i,lat)+rk21+rk22)
 !
             xiop2d(k,i,lat) =
      |        (0.5*(qop2d(k,i,lat)+qop2d(k+1,i,lat))+
      |        (rk20(k,i,lat)*ne(k,i,lat)+rk22)*xiop2p(k,i,lat))/
-     |        (rk23*n2_cm3+rk24*o1_cm3+rk26*o2_cm3+
+     |        (rk23*n2_cm3(k,i,lat)+rk24*o1_cm3(k,i,lat)+
+     |        rk26*o2_cm3(k,i,lat)+
      |        rk25(k,i,lat)*ne(k,i,lat)+rk27)
 !
-            op_loss(k,i,lat) =
-     |        rk1(k,i,lat)*o2_cm3+rk2(k,i,lat)*n2_cm3+rk10*n2d_cm3
+            op_loss(k,i,lat) = rk1(k,i,lat)*o2_cm3(k,i,lat)+
+     |        rk2(k,i,lat)*n2_cm3(k,i,lat)+rk10*n2d_cm3(k,i,lat)
 !
             q_coeff(k,i,lat) = q_coeff(k,i,lat)-op_loss(k,i,lat)
           enddo ! k=lev0,lev1-1
@@ -764,7 +769,8 @@
      |        0.5*(qop(k,i,lat)+qop(k+1,i,lat))+
      |        (rk19(k,i,lat)*ne(k,i,lat)+rk21)*xiop2p(k,i,lat)+
      |        (rk25(k,i,lat)*ne(k,i,lat)+rk27)*xiop2d(k,i,lat)+
-     |        (rk18*xiop2p(k,i,lat)+rk24*xiop2d(k,i,lat))*o1_cm3
+     |        (rk18*xiop2p(k,i,lat)+rk24*xiop2d(k,i,lat))*
+     |        o1_cm3(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -1,14 +1,9 @@
 !
       module oplus_module
 !
-! This software is part of the NCAR TIE-GCM.  Use is governed by the 
-! Open Source Academic Research License Agreement contained in the file 
+! This software is part of the NCAR TIE-GCM.  Use is governed by the
+! Open Source Academic Research License Agreement contained in the file
 ! tiegcmlicense.txt.
-!
-      use params_module,only: nlat,nlonp4,dz,nlon,dlev,nlevp1
-      use magfield_module,only: bx,by,bz,bmod2 ! (nlonp4,-1:nlat+2)
-      use addfld_module,only: addfld
-      use diags_module,only: mkdiag_BXYZ,mkdiag_BMAG
 !
 ! VT vampir tracing:
 !
@@ -17,36 +12,30 @@
 #endif
       implicit none
 !
+! 2024/09 Haonan Wu: rewrite the whole oplus module
+! to split calculations independent of O+ sub-cycling
+! this will speed up the model a little
+! when the number of O+ sub-cycling is large
+!
       contains
 !-----------------------------------------------------------------------
-      subroutine oplus(tn,te,ti,o2,o1,he,n2,n2d,ne,u,v,w,ui,vi,wi,
+      subroutine oplus(tn,te,ti,o2,o1,he,n2,n2d,ne,un,vn,w,ui,vi,wi,
      |  xnmbar,scht,op,optm1,opout,optm1out,xiop2p,xiop2d,Fe,Fn,
      |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
 ! Update O+ ion at 3d task subdomain.
-! Outputs are opout, optm1out, xiop2p, and xiop2d, all other args
-!   are input.
-! There are 4 latitude scans, with 3d mpi calls in between the loops.
-!   (see also 3d gather/scatter calls in sub filter_op).
+! Outputs are opout, optm1out, xiop2p, xiop2d, Fe, and Fn,
+! all other args are input.
 !
       use params_module,only: zpmid,spval  ! for O+ minimum
-      use cons_module,only: rmass_op,gask,grav,re,cs,dphi,dlamda,
-     |  shapiro,dtx2inv,rtd,rmassinv_o2,rmassinv_o1,
-     |  rmassinv_n2,rmassinv_n2d,dtsmooth,dtsmooth_div2
-      use qrj_module,only: 
-     |  qop2p, ! O+(2p) ionization from qrj, used in xiop2p
-     |  qop2d, ! O+(2d) ionization from qrj, used in xiop2d
-     |  qop    ! O+ ionization from qrj
-      use chemrates_module,only: ! needed chemical reaction rates
-     |  rk1 ,rk2 ,rk10,rk16,rk17,rk18,rk19,rk20,
-     |  rk21,rk22,rk23,rk24,rk25,rk26,rk27
+      use cons_module,only: rtd
       use input_module,only: nstep_sub,opfloor,oprate,oplev,oplatwidth
-      use magfield_module,only: dipmag,sndec,csdec,rlatm
-      use mpi_module,only: mp_bndlons_f3d, mp_periodic_f3d,
-     |  mp_polelats_f3d,mp_geo_halos_f3d,mp_bndlats_f3d
+      use magfield_module,only: rlatm
+      use mpi_module,only: mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
+      use addfld_module,only: addfld
 !
 ! Args:
-      integer,intent(in) :: 
+      integer,intent(in) ::
      |  lev0,lev1, ! first,last pressure  indices for current task (bot->top)
      |  lon0,lon1, ! first,last longitude indices for current task (W->E)
      |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
@@ -55,20 +44,16 @@
       real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(in) ::
      |  tn, te, ti, ! neutral, electron, and ion temperatures (deg K)
-     |  o2, o1,     ! o2, o mass mixing ratios
-     |  he,         ! he mass mixing ratio
-     |  n2d,        ! n2d
+     |  o2, o1, he, ! O2, O, He mass mixing ratios
+     |  n2,         ! N2 mass mixing ratio
+     |  n2d,        ! N(2D) mass mixing ratio
      |  ne,         ! electron density
-     |  u,v,w,      ! neutral wind velocities (zonal, meridional, omega)
-     |  optm1,      ! O+ at time n-1
-     |  op,         ! O+ ion
+     |  un,vn,w,    ! neutral wind velocities (zonal, meridional, omega)
      |  ui,vi,wi,   ! zonal, meridional, and vertical ion velocities
      |  xnmbar,     ! p0*e(-z)*mbar/kT
-     |  scht        ! scale height
-!
-! N2 is intent(inout) for setting halo points (mp_geo_halos_f3d call below)
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
-     |  intent(inout) :: n2
+     |  scht,       ! scale height
+     |  op,         ! O+ ion
+     |  optm1       ! O+ at time n-1
 !
 ! Output fields (full 3d task subdomain):
       real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
@@ -78,27 +63,14 @@
      |  xiop2p,xiop2d,Fe,Fn
 !
 ! Local:
-      integer :: k,i,lonbeg,lonend,lat,ier,nlevs
-      integer :: jm2,jm1,jp1,jp2 ! lat-2, lat-1, lat+1, lat+2 
-      real,dimension(lon0:lon1,lat0:lat1) :: 
-     |  opflux,    ! upward number flux of O+ (returned by sub oplus_flux) (t7)
-     |  dvb        ! output of sub divb
-      real,dimension(lon0:lon1) :: 
-     |  ubca, ubcb ! O+ upper boundary condition (were t2,t3)
-      real :: explic = 1., gmr
-      real,dimension(lev0:lev1,lon0:lon1) :: 
-     |  bdzdvb_op,        ! was s7
-     |  explicit,         ! was s4
-     |  hdz,              ! was s15
-     |  tphdz1,tphdz0,    ! were s13,s12 (using gmr)
-     |  djint,            ! was s11
-     |  divbz,            ! was s7 (DIV(B)+(DH*D*BZ)/(D*BZ)
-     |  hdzmbz,hdzpbz,    ! were s10,s9
-     |  p_coeff,q_coeff,r_coeff, ! coefficients for tridiagonal solver (s1,s2,s3)
-     |  tp1,              ! 0.5*(te+ti)
-     |  wd,bdotdh_djbz,op_prod,op_loss_out,dopdt,
-     |  diffsum,driftsum,windsum
-      real,dimension(lev0:lev1,lon0:lon1,lat0-1:lat1+1) :: hj ! (s10-s12)
+      integer :: k,i,lat,nlevs,istep
+      real,dimension(lon0-2:lon1+2,lat0-2:lat1+2) :: dvb,ubcrhs,lbcrhs
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
+     |  dj,tp,bdotu,op_prod,op_loss,diffp,diffq,diffr,
+     |  driftp,driftq,driftr,windp,windq,windr,
+     |  p_coeff,q_coeff,r_coeff,optm1_smooth,
+     |  op_sub,optm1_sub,opout_sub,optm1out_sub,
+     |  diffj,diffexp,vdotn_h,bdotdh_bvel
 !
 ! For O+ "smooth floor". The floor is a
 ! spatial gaussian based on the O+ minimum (opmin below).
@@ -106,55 +78,211 @@
 ! 1/21/16 btf: O+ minimum increased from 1000 to 3000.
 ! (This alleviates numerical instability that can develop
 !  near the equator at the top of the model in some cases,
-!  e.g., it allows the 2.5-deg June solstice solar max 
+!  e.g., it allows the 2.5-deg June solstice solar max
 !  benchmark to run with step=30 rather than step=20, and
 !  may improve stability in other cases as well.)
 !
       real :: opmin
 !
-! Local fields at 3d subdomain (must be 3d to bridge latitude scans):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) :: 
-     |  bdotu,       ! was s7 (B.U)
-     |  bvel,
-     |  diffj,       ! (D/(H*DZ)*2.*TP+M*G/R)*N(O+) (s7,s8,s9)
-     |  tp,          ! Plasma temperature (te+ti)
-     |  tr,          ! Reduced temperature 0.5*(tn+ti)
-     |  bdotdh_op,   ! (b(h)*del(h))*phi
-     |  bdotdh_opj,  ! (b(h)*del(h))*phi
-     |  bdotdh_diff, ! (b(h)*del(h))*phi
+! Number of pressure levels (this will equal nlevp1):
+      nlevs = lev1-lev0+1 ! for bndlons calls
+!
+      call prep_oplus(tn,te,ti,
+     |  o2,o1,he,n2,n2d,ne,un,vn,w,wi,xnmbar,scht,
+     |  dvb,ubcrhs,lbcrhs,dj,tp,bdotu,xiop2p,xiop2d,
+     |  op_prod,op_loss,diffp,diffq,diffr,
+     |  driftp,driftq,driftr,windp,windq,windr,
+     |  p_coeff,q_coeff,r_coeff,
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
+!
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1
+            op_sub(k,i,lat) = op(k,i,lat)
+            optm1_sub(k,i,lat) = optm1(k,i,lat)
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+!
+      do istep=1,nstep_sub
+        call smooth_oplus(optm1_sub,optm1_smooth,
+     |    lev0,lev1,lon0,lon1,lat0,lat1)
+!
+        call iterate_oplus(dvb,ubcrhs,lbcrhs,dj,tp,bdotu,
+     |    optm1_smooth,op_prod,ui,vi,scht,p_coeff,q_coeff,r_coeff,
+     |    op_sub,opout_sub,diffj,diffexp,vdotn_h,bdotdh_bvel,
+     |    lev0,lev1,lon0,lon1,lat0,lat1)
+!
+        if (istep == nstep_sub) then
+          call calc_terms(xnmbar,diffj,Fe,Fn,
+     |      opout_sub,optm1_smooth,op_prod,op_loss,
+     |      diffexp,diffp,diffq,diffr,
+     |      vdotn_h,driftp,driftq,driftr,
+     |      bdotdh_bvel,windp,windq,windr,
+     |      lev0,lev1,lon0,lon1,lat0,lat1)
+        endif
+!
+! Filter updated O+:
+!
+        call filter_op(opout_sub(:,lon0:lon1,lat0:lat1),
+     |    lev0,lev1,lon0,lon1,lat0,lat1,'OPLUS')
+!
+!       do lat=lat0,lat1
+!         call addfld('OP_FILT',' ',' ',
+!    |      opout_sub(lev0:lev1-1,lon0:lon1,lat),
+!    |      'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       enddo ! lat=lat0,lat1
+!
+! 12/4/14 btf: Enforce O+ minimum.
+! Opfloor is Stan's "smooth floor" (product of two Gaussians,
+!   dependent on latitude and pressure level) (opmin=1000.0):
+!
+! 2024/08 Haonan Wu:
+!   Change the altitude distribution of O+ minimum from Gaussian to logistic,
+!   also change the latitude distribution based on magnetic latitudes
+!   instead of geographic latitudes
+!
+        if (opfloor/=0. .and. oprate/=0. .and.
+     |      oplev/=spval .and. oplatwidth/=0.) then
+          do lat=lat0,lat1
+            do i=lon0,lon1
+              do k=lev0,lev1-1
+                opmin = opfloor*exp(-(rlatm(i,lat)*rtd/oplatwidth)**2)/
+     |            (1+exp(-oprate*(zpmid(k)-oplev)))
+                if (opout_sub(k,i,lat) < opmin) then
+                  opout_sub(k,i,lat) = opmin
+                endif ! opout_sub < opmin
+              enddo ! k=lev0,lev1-1
+            enddo ! i=lon0,lon1
+          enddo ! lat=lat0,lat1
+        endif
+!
+        call mp_polelats_f3d(opout_sub(:,lon0:lon1,:),
+     |    lev0,lev1,lon0,lon1,lat0,lat1,1,(/1./))
+        call mp_bndlats_f3d(opout_sub,nlevs,lon0,lon1,lat0,lat1,1)
+        call mp_bndlons_f3d(opout_sub,nlevs,lon0,lon1,lat0,lat1,1,0)
+!
+        call post_oplus(op_sub,optm1_sub,opout_sub,optm1out_sub,
+     |    lev0,lev1,lon0,lon1,lat0,lat1)
+!
+        do lat=lat0-2,lat1+2
+          do i=lon0-2,lon1+2
+            do k=lev0,lev1
+              op_sub(k,i,lat) = opout_sub(k,i,lat)
+              optm1_sub(k,i,lat) = optm1out_sub(k,i,lat)
+            enddo ! k=lev0,lev1
+          enddo ! i=lon0-2,lon1+2
+        enddo ! lat=lat0-2,lat1+2
+      enddo ! istep=1,nstep_sub
+!
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1
+            opout(k,i,lat) = opout_sub(k,i,lat)
+            optm1out(k,i,lat) = optm1out_sub(k,i,lat)
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+!
+      end subroutine oplus
+!-----------------------------------------------------------------------
+      subroutine prep_oplus(tn,te,ti,
+     |  o2,o1,he,n2,n2d,ne,un,vn,w,wi,xnmbar,scht,
+     |  dvb,ubcrhs,lbcrhs,dj,tp,bdotu,xiop2p,xiop2d,
+     |  op_prod,op_loss,diffp,diffq,diffr,
+     |  driftp,driftq,driftr,windp,windq,windr,
+     |  p_coeff,q_coeff,r_coeff,
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
+!
+! Calculate terms that are not changing across O+ sub-cycling
+!
+      use params_module,only: nlonp4,dz,zpmid,spval
+      use cons_module,only: rmass_op,gask,grav,re,cs,dphi,dlamda,
+     |  dtx2inv,pi,dtr,rmassinv_o2,rmassinv_o1,
+     |  rmassinv_he,rmassinv_n2,rmassinv_n2d
+      use input_module,only: nstep_sub,colfac,
+     |  opdiffcap,opdiffrate,opdifflev
+      use chapman_module,only: chi     ! was t2 in old sub opflux
+      use qrj_module,only:
+     |  qop2p, ! O+(2p) ionization from qrj, used in xiop2p
+     |  qop2d, ! O+(2d) ionization from qrj, used in xiop2d
+     |  qop    ! O+ ionization from qrj
+      use chemrates_module,only: ! needed chemical reaction rates
+     |  rk1 ,rk2 ,rk10,rk16,rk17,rk18,rk19,rk20,
+     |  rk21,rk22,rk23,rk24,rk25,rk26,rk27
+      use magfield_module,only: bx,by,bz,bmod2, ! (nlonp4,-1:nlat+2)
+     |  rlatm
+      use mpi_module,only: mp_periodic_f2d,
+     |  mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
+      use addfld_module,only: addfld
+      use diags_module,only: mkdiag_BXYZ,mkdiag_BMAG
+!
+! Args:
+      integer,intent(in) ::
+     |  lev0,lev1, ! first,last pressure  indices for current task (bot->top)
+     |  lon0,lon1, ! first,last longitude indices for current task (W->E)
+     |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
+!
+! Input fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(in) ::
+     |  tn, te, ti, ! neutral, electron, and ion temperatures (deg K)
+     |  o2, o1, he, ! O2, O, He mass mixing ratios
+     |  n2,         ! N2 mass mixing ratio
+     |  n2d,        ! N(2D) mass mixing ratio
+     |  ne,         ! electron density
+     |  un,vn,w,    ! neutral wind velocities (zonal, meridional, omega)
+     |  wi,         ! vertical ion velocities
+     |  xnmbar,     ! p0*e(-z)*mbar/kT
+     |  scht        ! scale height
+!
+! Output fields (full 2d task subdomain):
+      real,dimension(lon0-2:lon1+2,lat0-2:lat1+2),intent(out) ::
+     |  dvb,        ! output of sub divb
+     |  ubcrhs,lbcrhs
+!
+! Output fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(out) ::
      |  dj,          ! diffusion coefficients (s13,s14,s15)
-     |  optm1_smooth,! op at time n-1, with shapiro smoother (was s1)
-     |  optm1_smooth2,
-     |  op_loss,     ! was s13
-     |  vni,djbz,vdotn_h,bdotdh_bvel,diffexp,
-     |  diffp,diffq,diffr,driftp,driftq,driftr,windp,windq,windr
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,5) :: f5
-      logical,parameter :: debug=.false. ! if set write print statements to stdout
+     |  tp,          ! Plasma temperature 0.5*(te+ti)
+     |  bdotu,       ! was s7 (B.U)
+     |  xiop2p,xiop2d,
+     |  op_prod,op_loss,diffp,diffq,diffr,
+     |  driftp,driftq,driftr,windp,windq,windr,
+     |  p_coeff,q_coeff,r_coeff ! coefficients for tridiagonal solver (s1,s2,s3)
 !
-! External:
-      real,external :: fslt
-!
-      if (debug) write(6,"('Enter oplus.')")
-#ifdef VT
-!     code = 113 ; state = 'oplus' ; activity='ModelCode'
-      call vtbegin(113,ier)
-#endif
+! Local:
+      real,parameter ::
+     |  phid =  2.0e8,
+     |  phin = -2.0e8,
+     |  ppolar = 0.
+      integer :: k,i,lat,lonbeg,lonend,nlevs
+      real :: gmr,a,fed,fen,dbxdx,dbydy,tr,djmin,
+     |  o2_cm3,o1_cm3,n2_cm3,he_cm3,n2d_cm3,
+     |  ubca, ubcb ! O+ upper boundary condition (were t2,t3)
+      real,dimension(lev0:lev1) :: bdotu1
+      real,dimension(lon0:lon1,lat0:lat1) ::
+     |  opflux,    ! upward number flux of O+ (returned by sub oplus_flux) (t7)
+     |  dvb_bz
+      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
+     |  hdz,              ! was s15
+     |  tphdz1,tphdz0,    ! were s13,s12 (using gmr)
+     |  djint,            ! was s11
+     |  divbz,            ! was s7 (DIV(B)+(DH*D*BZ)/(D*BZ)
+     |  hdzmbz,hdzpbz,    ! were s10,s9
+     |  tp1,              ! 0.5*(te+ti)
+     |  hdzi,bdotdh_djbz,
+     |  djint_tphdz0,djint_tphdz1,
+     |  djint_tphdz0_1,djint_tphdz1_1
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) :: djbz
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) :: tmpf3d
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
-
-!
-! Make latitudes j=-1,0 from j=2,1, and j=nlat+1,nlat+2 from nlat-1,nlat for n2, 
-! then define 2d halos points.  Note that mp_geo_halos_f3d and mp_polelats_f3d 
-! do not define "outside corner" halo points, but this should be ok since 
-! cross-derivatives are not performed.
-!
-      call mp_polelats_f3d(n2(:,lon0:lon1,:),   ! 3rd dim is lat0-2:lat1+2
-     |  lev0,lev1,lon0,lon1,lat0,lat1,1,(/1./)) ! last arg means no change in polesign
-      call mp_geo_halos_f3d(n2,lev0,lev1,lon0,lon1,lat0,lat1,1)      
 !
 ! Save inputs to secondary history file:
-! 
+!
 !     do lat=lat0,lat1
 !       call addfld('TE_OP',' ',' ',te(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
@@ -164,29 +292,59 @@
 !    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
 !       call addfld('NE_OP',' ',' ',ne(:,lon0:lon1,lat),
 !    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OPTM1',' ',' ',optm1(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OP_OPLUS',' ',' ',op(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('UI_OP',' ',' ',ui(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('VI_OP',' ',' ',vi(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
 !       call addfld('WI_OP',' ',' ',wi(:,lon0:lon1,lat),
 !    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
 !     enddo ! lat=lat0,lat1
 !
-! Sub oplus_flux returns upward number flux of O+ in 
+! Calculate O+ number flux in opflux for sub oplus (was sub opflux).
 !
-      call oplus_flux(opflux,lon0,lon1,lat0,lat1)
-      if (debug) write(6,"('oplus after oplus_flux.')")
+! Change upper boundary flux as electron heat flux in settei
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          if (abs(rlatm(i,lat)) >= pi/4.5) then
+            a = 1.
+          elseif (abs(rlatm(i,lat)) <= pi/18.) then
+            a = 0.
+          else
+            a = .5*(1.-cos(abs(rlatm(i,lat))*6.-pi/3.))
+          endif
+          fed = phid*a
+          fen = phin*a
+          if (chi(i,lat) >= 100.*dtr) then
+            opflux(i,lat) = fen
+          elseif (chi(i,lat) <= 80.*dtr) then
+            opflux(i,lat) = fed
+          else
+            opflux(i,lat) = .5*(fed+fen+(fed-fen)*cos(chi(i,lat)*9.))
+          endif
+!
+! Add ppolar if magnetic latitude >= 60 degrees:
+          if (abs(rlatm(i,lat)) >= pi/3.)
+     |      opflux(i,lat) = opflux(i,lat)+ppolar
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !     call addfld('OPFLUX',' ',' ',opflux,
 !    |  'lon',lon0,lon1,'lat',lat0,lat1,0)
 !
-! Divergence is returned in dvb(lon0:lon1,lat0:lat1) by sub divb:
-      call divb(dvb,lon0,lon1,lat0,lat1)
-      if (debug) write(6,"('oplus after divb.')")
-!     call addfld('OP_DIVB',' ',' ',dvb,
+! Evaluate divergence of B, the unit magnetic field vector.
+!
+      lonbeg = lon0
+      if (lon0==1) lonbeg = 3
+      lonend = lon1
+      if (lon1==nlonp4) lonend = nlonp4-2
+!
+      dvb = 0.
+      do lat=lat0,lat1
+        do i=lonbeg,lonend
+          dbxdx = (bx(i+1,lat)-bx(i-1,lat))/(2.*dlamda)
+          dbydy =
+     |      (cs(lat+1)*by(i,lat+1)-cs(lat-1)*by(i,lat-1))/(2.*dphi)
+          dvb(i,lat) = ((dbxdx+dbydy)/cs(lat)+2.*bz(i,lat))/re
+        enddo ! i=lonbeg,lonend
+      enddo ! lat=lat0,lat1
+      call mp_periodic_f2d(dvb(lon0:lon1,lat0:lat1),
+     |  lon0,lon1,lat0,lat1,1)
+!     call addfld('OP_DIVB',' ',' ',dvb(lon0:lon1,lat0:lat1),
 !    |  'lon',lon0,lon1,'lat',lat0,lat1,0)
 !
       call mkdiag_BXYZ('BX',bx(lon0:lon1,lat0:lat1),lon0,lon1,lat0,lat1)
@@ -195,727 +353,919 @@
       call mkdiag_BMAG('BMAG',bmod2(lon0:lon1,lat0:lat1),
      |  lon0,lon1,lat0,lat1)
 !
-!----------------------- Begin first latitude scan ---------------------
-      do lat=lat0,lat1
-        if (debug) write(6,"('oplus begin first lat scan: lat=',i3)")lat
-        jm2 = lat-2
-        jm1 = lat-1
-        jp1 = lat+1
-        jp2 = lat+2
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
 !
 ! Set reduced temperature (average of tn and ti)
 !
-! 1/2/16 btf: 
-!   This was previously set incorrectly as tp = 0.5*(te+ti)) 
+! 1/2/16 btf:
+!   This was previously set incorrectly as tp = 0.5*(te+ti))
 !   (see also plasma temp tp). Correcting this resulted in a
 !   40% change in ambipolar diffusion DJ, but only 10% or so
 !   change in O+ and Ne, and very small differences in NMF2,HMF2,TEC.
 !   Wenbin feels there should be larger changes in these fields
-!   as a consequence of fixing this bug. 
+!   as a consequence of fixing this bug.
 !
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          tr(k,i,jm1) = 0.5*(tn(k,i,jm1)+ti(k,i,jm1))
-          tr(k,i,lat) = 0.5*(tn(k,i,lat)+ti(k,i,lat))
-          tr(k,i,jp1) = 0.5*(tn(k,i,jp1)+ti(k,i,jp1))
-        enddo
-      enddo
-      tr(lev1,:,:) = 0.
-!     call addfld('TR','TR: reduced temperature (0.5*(tn+ti))',' ',
-!    |  tr(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+            tr = 0.5*(tn(k,i,lat)+ti(k,i,lat))
+            o2_cm3 = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
+            o1_cm3 = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
+            he_cm3 = xnmbar(k,i,lat)*he(k,i,lat)*rmassinv_he
+            n2_cm3 = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
 !
-! rrk returns djm1,dj,djp1:
+! 8/28/13 btf: Use n2=1-o2-o-he, and include O+/He collision rate from Wenbin:
 !
-      call rrk(xnmbar(:,lon0:lon1,jm1),
-     |  o2(:,lon0:lon1,jm1),o1(:,lon0:lon1,jm1),
-     |  he(:,lon0:lon1,jm1),n2(:,lon0:lon1,jm1),
-     |  tr(:,lon0:lon1,jm1),dj(:,lon0:lon1,jm1),
-     |  vni(:,lon0:lon1,jm1),lon0,lon1,lev0,lev1)
+            dj(k,i,lat) = 1.42E17/(18.1*o2_cm3+3.6*he_cm3+18.6*n2_cm3+
+     |        o1_cm3*sqrt(tr)*(1.-0.064*log10(tr))**2*colfac)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+!
+! 1/30/16 btf:
+! Cap ambipolar diffusion coefficient. Namelist parameter OPDIFFCAP.
+! This was tested with various values (1.5e8, 3e8, 6e8, 8e8),
+! and was found to improve numerical stability in some storm cases,
+! for example the November, 2003 and July, 2000 storms, with Weimer
+! potential model and IMF/OMNI data. Both of these cases generally
+! will not complete if timestep is longer than 10 sec. The Nov, 2003
+! may succeed with opdiffcap turned off, but the July, 2000
+! "Bastille day storm" will succeed only with step=10 and opdiffcap=6.e8.
+!
+! 2024/08 Haonan Wu: Change the original constant O+ diffusion cap
+!   to an altitude-dependent cap (use logistic function for now)
+!
+      if (opdiffcap/=0. .and. opdiffrate/=0. .and. opdifflev/=spval)
+     |  then
+        do lat=lat0-2,lat1+2
+          do i=lon0-2,lon1+2
+            do k=lev0,lev1-1
+              djmin = opdiffcap/(1+exp(opdiffrate*(zpmid(k)-opdifflev)))
+              if (dj(k,i,lat) > djmin) dj(k,i,lat) = djmin
+            enddo ! k=lev0,lev1-1
+          enddo ! i=lon0-2,lon1+2
+        enddo ! lat=lat0-2,lat1+2
+      endif
 
-      call rrk(xnmbar(:,lon0:lon1,lat),
-     |  o2(:,lon0:lon1,lat),o1(:,lon0:lon1,lat),
-     |  he(:,lon0:lon1,lat),n2(:,lon0:lon1,lat),
-     |  tr(:,lon0:lon1,lat),dj(:,lon0:lon1,lat),
-     |  vni(:,lon0:lon1,lat),lon0,lon1,lev0,lev1)
-
-      call rrk(xnmbar(:,lon0:lon1,jp1),
-     |  o2(:,lon0:lon1,jp1),o1(:,lon0:lon1,jp1),
-     |  he(:,lon0:lon1,jp1),n2(:,lon0:lon1,jp1),
-     |  tr(:,lon0:lon1,jp1),dj(:,lon0:lon1,jp1),
-     |  vni(:,lon0:lon1,jp1),lon0,lon1,lev0,lev1)
-
-      if (debug) write(6,"('oplus after rrk: lat=',i3)") lat
-!     call addfld('DJ','DJ: Ambipolar Diffusion of O+',' ',
+!     do lat=lat0,lat1
+!       call addfld('DJ','DJ: Ambipolar Diffusion of O+',' ',
 !    |    dj(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
 !
 ! Plasma temperature:
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          tp(k,i,jm1) = te(k,i,jm1)+ti(k,i,jm1)
-          tp(k,i,lat) = te(k,i,lat)+ti(k,i,lat)
-          tp(k,i,jp1) = te(k,i,jp1)+ti(k,i,jp1)
-        enddo
-      enddo
-      if (debug) write(6,"('oplus after tpj: lat=',i3)") lat
-!
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          hj(k,i,jm1) = scht(k,i,jm1)
-          hj(k,i,lat) = scht(k,i,lat)
-          hj(k,i,jp1) = scht(k,i,jp1)
-        enddo
-      enddo
-      if (debug) write(6,"('oplus after hj: lat=',i3)") lat
-!     call addfld('HJ  ',' ',' ',hj(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            tp(k,i,lat) = 0.5*(te(k,i,lat)+ti(k,i,lat))
+          enddo ! k=lev0,lev1-1
+          tp(lev1,i,lat) = 2.*tp(lev1-1,i,lat)-tp(lev1-2,i,lat)
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
 !
 ! bdotu = B.U (s7)
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          bdotu(k,i,jm1) = bx(i,jm1)*u(k,i,jm1)+by(i,jm1)*v(k,i,jm1)+
-     |      hj(k,i,jm1)*bz(i,jm1)*0.5*(w(k,i,jm1)+w(k+1,i,jm1))
-          bdotu(k,i,lat) = bx(i,lat)*u(k,i,lat)+by(i,lat)*v(k,i,lat)+
-     |      hj(k,i,lat)*bz(i,lat)*0.5*(w(k,i,lat)+w(k+1,i,lat))
-          bdotu(k,i,jp1) = bx(i,jp1)*u(k,i,jp1)+by(i,jp1)*v(k,i,jp1)+
-     |      hj(k,i,jp1)*bz(i,jp1)*0.5*(w(k,i,jp1)+w(k+1,i,jp1))
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-!     call addfld('BDOTU' ,' ',' ',bdotu(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! bvel @ jm1 = (B.U)*N(O+)    (J-1) (was s6)
-! bvel @ j   = (B.U)*N(O+)      (J) (was s7)
-! bvel @ jp1 = (B.U)*N(O+)    (J+1) (was s8)
-!
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          bvel(k,i,jm1) = bdotu(k,i,jm1)*op(k,i,jm1)
-          bvel(k,i,lat) = bdotu(k,i,lat)*op(k,i,lat)
-          bvel(k,i,jp1) = bdotu(k,i,jp1)*op(k,i,jp1)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-      if (debug) write(6,"('oplus after bvel: lat=',i3)") lat
-!     call addfld('BVEL_J'  ,' ',' ',bvel(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-      tp(lev1,:,jm1:jp1) = 0.
-      call diffus(
-     |  tp(:,lon0:lon1,jm1),op(:,lon0:lon1,jm1),hj(:,:,jm1),
-     |  diffj(:,lon0:lon1,jm1),lon0,lon1,lev0,lev1)
-      call diffus(
-     |  tp(:,lon0:lon1,lat),op(:,lon0:lon1,lat),hj(:,:,lat),
-     |  diffj(:,lon0:lon1,lat),lon0,lon1,lev0,lev1)
-      call diffus(
-     |  tp(:,lon0:lon1,jp1),op(:,lon0:lon1,jp1),hj(:,:,jp1),
-     |  diffj(:,lon0:lon1,jp1),lon0,lon1,lev0,lev1)
-
-      if (debug) write(6,"('oplus after diffus: lat=',i3)") lat
-!     call addfld('DIFFJ','DIFFJ after diffus',' ',
-!    |  diffj(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! Plasma temperature times O+
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          tp(k,i,jm2) = op(k,i,jm2)*(te(k,i,jm2)+ti(k,i,jm2))
-          tp(k,i,jm1) = tp(k,i,jm1)*op(k,i,jm1)
-          tp(k,i,lat) = tp(k,i,lat)*op(k,i,lat)
-          tp(k,i,jp1) = tp(k,i,jp1)*op(k,i,jp1)
-          tp(k,i,jp2) = op(k,i,jp2)*(te(k,i,jp2)+ti(k,i,jp2))
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-      if (debug) write(6,"('oplus after tpj2: lat=',i3)") lat
-!     call addfld('TPJ','TP after times OP',' ',
-!    |  tp(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! Shapiro smoother: optm1 is O+ at time n-1 (optm1_smooth was s1)
-! optm1_smooth will be used in explicit terms below.
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          optm1_smooth(k,i,lat) = optm1(k,i,lat)-shapiro/nstep_sub*
-     |      (optm1(k,i,jp2)+optm1(k,i,jm2)-4.*
-     |      (optm1(k,i,jp1)+optm1(k,i,jm1))+6.*
-     |       optm1(k,i,lat))
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-!     call addfld('OPTM1_SM0' ,' ',' ',
-!    |  optm1_smooth(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-        if (debug) write(6,"('oplus end first lat scan: lat=',i3)") lat
-      enddo ! lat=lat0,lat1
-!
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
-            wd(k,i) = vni(k,i,lat)*diffj(k,i,lat)*dj(k,i,lat)*
-     |        sin(dipmag(i,lat))*cos(dipmag(i,lat))
-            Fe(k,i,lat) = wd(k,i)*sndec(i,lat)
-            Fn(k,i,lat) = wd(k,i)*csdec(i,lat)
-          enddo
-        enddo
-      enddo
-
-      do lat=lat0-1,lat1+1
+            bdotu(k,i,lat) =
+     |        bx(i,lat)*un(k,i,lat)+by(i,lat)*vn(k,i,lat)+
+     |        bz(i,lat)*scht(k,i,lat)*0.5*(w(k,i,lat)+w(k+1,i,lat))
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+!       call addfld('BDOTU' ,' ',' ',bdotu(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+      do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
             djbz(k,i,lat) = dj(k,i,lat)*bz(i,lat)
-          enddo
-        enddo
-      enddo
-!------------------------- End first latitude scan ---------------------
-!
-! Boundary longitudes:
-      f5(:,:,:,1) = djbz(:,:,:)
-      f5(:,:,:,2) = bvel(:,:,:)
-      f5(:,:,:,3) = diffj(:,:,:)
-      f5(:,:,:,4) = tp(:,:,:)
-      f5(:,:,:,5) = optm1_smooth(:,:,:)
-
-      call mp_bndlons_f3d(f5,nlevs,lon0,lon1,lat0,lat1,5,0)
-
-      djbz(:,:,:)         = f5(:,:,:,1)
-      bvel(:,:,:)         = f5(:,:,:,2)
-      diffj(:,:,:)        = f5(:,:,:,3)
-      tp(:,:,:)          = f5(:,:,:,4)
-      optm1_smooth(:,:,:) = f5(:,:,:,5)
-!
-!----------------------- Begin second latitude scan --------------------
-      do lat=lat0,lat1
-        if (debug) 
-     |    write(6,"('oplus begin second lat scan: lat=',i3)") lat
-        jm2 = lat-2
-        jm1 = lat-1
-        jp1 = lat+1
-        jp2 = lat+2
-!
-! bdotdh_op = (B(H).DEL(H))*(D/(H*DZ)*TP+M*G/R)*N(O+)
-! then bdotdh_op = d*bz*bdotdh_op
-!
-        call bdotdh(
-     |    diffj(:,lon0:lon1,jm1),
-     |    diffj(:,:,lat),
-     |    diffj(:,lon0:lon1,jp1),
-     |    bdotdh_op(:,lon0:lon1,lat),lon0,lon1,lev0,lev1,lat)
-!
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          bdotdh_op(k,i,lat) = djbz(k,i,lat)*bdotdh_op(k,i,lat)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-
-!     call addfld('BDOTDH_1',' ',' ',
-!    |  bdotdh_op(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! bdotdh_opjm1 = (B(H).DEL(H))*2.*TP*N(O+)    (J-1)
-! bdotdh_opj   = (B(H).DEL(H))*2.*TP*N(O+)      (J)
-! bdotdh_opjp1 = (B(H).DEL(H))*2.*TP*N(O+)    (J+1)
-!
-      call bdotdh(
-     |  tp(:,lon0:lon1,jm2),tp(:,:,jm1),tp(:,lon0:lon1,lat),
-     |  bdotdh_opj(:,lon0:lon1,jm1),lon0,lon1,lev0,lev1,jm1)
-      call bdotdh(
-     |  tp(:,lon0:lon1,jm1),tp(:,:,lat),tp(:,lon0:lon1,jp1),
-     |  bdotdh_opj(:,lon0:lon1,lat),lon0,lon1,lev0,lev1,lat)
-      call bdotdh(
-     |  tp(:,lon0:lon1,lat),tp(:,:,jp1),tp(:,lon0:lon1,jp2),
-     |  bdotdh_opj(:,lon0:lon1,jp1),lon0,lon1,lev0,lev1,jp1)
-!
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          bdotdh_opj(k,i,jm1) = bdotdh_opj(k,i,jm1)*dj(k,i,jm1)
-          bdotdh_opj(k,i,lat) = bdotdh_opj(k,i,lat)*dj(k,i,lat)
-          bdotdh_opj(k,i,jp1) = bdotdh_opj(k,i,jp1)*dj(k,i,jp1)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-
-!     call addfld('BDOTDH_2',' ',' ',
-!    |  bdotdh_op(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-        if (debug) 
-     |    write(6,"('oplus end second lat scan: lat=',i3)") lat
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
-!------------------------ End second latitude scan ---------------------
 !
-! Periodic points for bdotdh_opj (output from bdotdh above):
-      call mp_periodic_f3d(bdotdh_opj(:,lon0:lon1,lat0:lat1),
-     |  lev0,lev1,lon0,lon1,lat0,lat1,1)
-!
-! Boundary longitudes for bdotdh_opj (input to below call to bdotdh):
-      call mp_bndlons_f3d(bdotdh_opj,nlevs,lon0,lon1,lat0,lat1,1,0)
-!
-!----------------------- Begin third latitude scan ---------------------
+! Fill up halo points of bdotu, djbz (used in bdotdh calls)
       do lat=lat0,lat1
-        if (debug) 
-     |    write(6,"('oplus begin third lat scan: lat=',i3)") lat
-        jm2 = lat-2
-        jm1 = lat-1
-        jp1 = lat+1
-        jp2 = lat+2
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            tmpf3d(k,i,lat,1) = bdotu(k,i,lat)
+            tmpf3d(k,i,lat,2) = djbz(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+      call mp_polelats_f3d(tmpf3d(:,lon0:lon1,:,:),
+     |  lev0,lev1,lon0,lon1,lat0,lat1,2,(/1.,1./))
+      call mp_bndlats_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2)
+      call mp_bndlons_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2,0)
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            bdotu(k,i,lat) = tmpf3d(k,i,lat,1)
+            djbz(k,i,lat) = tmpf3d(k,i,lat,2)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
 !
-! bdotdh_opj = (B(H).DEL(H))*D*(B(H).DEL(H))*2.*TP*N(O+)   (J)
-! Note bdotdh_opj longitude dimension is lon-2:lon+2. bdotdh_diff 
-!   is returned. (periodic points apparently not necessary for
-!   bdotdh_diff)
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          dvb_bz(i,lat) = dvb(i,lat)/bz(i,lat)
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !
-      call bdotdh(
-     |  bdotdh_opj(:,lon0:lon1,jm1),
-     |  bdotdh_opj(:,:,lat),
-     |  bdotdh_opj(:,lon0:lon1,jp1),
-     |  bdotdh_diff(:,lon0:lon1,lat),lon0,lon1,lev0,lev1,lat)
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1
+            hdz(k,i,lat) = 1./(scht(k,i,lat)*dz)
+          enddo ! k=lev0,lev1
+          do k=lev0,lev1-1
+            tp1(k+1,i,lat) = tp(k,i,lat)
+          enddo ! k=lev0,lev1-1
+          tp1(lev0,i,lat) = 2.*tp(lev0,i,lat)-tp(lev0+1,i,lat)
+        enddo ! i=lon0,lon1
 
-!     call addfld('BDOT_J'  ,' ',' ',bdotdh_opj(lev0:lev1-1,lon0:lon1,
-!    |  lat),'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('BDOT_DIF',' ',' ',bdotdh_diff(lev0:lev1-1,lon0:lon1,
-!    |  lat),'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! bdzdvb_op = (BZ*D/(H*DZ)+DIV(*B))*S2
-! bdzdvb returns bdzdvb_op.
-!
-      call bdzdvb(bdotdh_opj(:,lon0:lon1,lat),dvb(:,lat),hj(:,:,lat),
-     |  bdzdvb_op,lev0,lev1,lon0,lon1,lat)
-
-!     call addfld('BDZDVB',' ',' ',
-!    |  bdzdvb_op(lev0:lev1-1,:),'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! Collect explicit terms:
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          diffexp(k,i,lat) =
-     |      bdzdvb_op(k,i)+bdotdh_diff(k,i,lat)+bdotdh_op(k,i,lat)
-          explicit(k,i) = -explic*diffexp(k,i,lat)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-
-!     call addfld('EXPLIC0',' ',' ',explicit(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('BX_OP',' ',' ',bx(lon0:lon1,:),
-!    |  'lon',lon0,lon1,'lat',lat,lat,0)
-!     call addfld('BY_OP',' ',' ',by(lon0:lon1,:),
-!    |  'lon',lon0,lon1,'lat',lat,lat,0)
-!     call addfld('UI_VEL',' ',' ',ui(:,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('VI_VEL',' ',' ',vi(:,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
- 
-      lonbeg = lon0
-      if (lon0==1) lonbeg = 3
-      lonend = lon1
-      if (lon1==nlonp4) lonend = lon1-2
-!
-      call bdotdh(
-     |  bvel(:,lon0:lon1,jm1),bvel(:,:,lat),bvel(:,lon0:lon1,jp1),
-     |  bdotdh_bvel(:,lon0:lon1,lat),lon0,lon1,lev0,lev1,lat)
-!
-! Note if input flag DYNAMO<=0, then ui,vi,wi velocities will be zero.
-      do i=lonbeg,lonend
-        do k=lev0,lev1-1
-          vdotn_h(k,i,lat) = 1./(2.*re)*
-     |      (1./(cs(lat)*dlamda)*
-     |      (0.5*(ui(k,i,lat)+ui(k+1,i,lat))*bmod2(i,lat)**2*
-     |      (op(k,i+1,lat)/bmod2(i+1,lat)**2-
-     |       op(k,i-1,lat)/bmod2(i-1,lat)**2))+
-!
-     |      1./dphi*
-     |      (0.5*(vi(k,i,lat)+vi(k+1,i,lat))*bmod2(i,lat)**2*
-     |      (op(k,i,jp1)/bmod2(i,jp1)**2-
-     |       op(k,i,jm1)/bmod2(i,jm1)**2)))
-          explicit(k,i) =
-     |      explicit(k,i)+vdotn_h(k,i,lat)+bdotdh_bvel(k,i,lat)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0+2,lon1-2
-!
-! Periodic points for explicit terms.
-! This is apparently unnecessary:
-!     call periodic_f2d(explicit,lon0,lon1,nlevs)
-
-!     call addfld('EXPLIC1',' ',' ',explicit(lev0:lev1-1,:),
+!       call addfld('TP1',' ',' ',tp1(lev0:lev1-1,:,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-
-      do i=lon0,lon1
-        dvb(i,lat) = dvb(i,lat)/bz(i,lat)
-      enddo ! i=lon0,lon1
-!      
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          hdz(k,i) = 1./(hj(k,i,lat)*dz)
-          tp1(k,i) = 0.5*(ti(k,i,lat)+te(k,i,lat))
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-
-!     call addfld('TP1',' ',' ',tp1(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('HDZ',' ',' ',hdz(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('HDZ',' ',' ',hdz(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-2
+            hdzi(k+1,i,lat) = 0.5*(hdz(k,i,lat)+hdz(k+1,i,lat))
+          enddo ! k=lev0,lev1-2
+!
+! Upper and lower boundaries:
+          hdzi(lev0,i,lat) = 1.5*hdz(lev0  ,i,lat)-0.5*hdz(lev0+1,i,lat)
+          hdzi(lev1,i,lat) = 1.5*hdz(lev1-1,i,lat)-0.5*hdz(lev1-2,i,lat)
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !
 ! gmr = G*M(O+)/(2.*R)
       gmr = grav*rmass_op/(2.*gask)
-      do i=lon0,lon1
-        do k=lev0,lev1-2
-          tphdz1(k+1,i) = 2.*tp1(k+1,i)*(0.5*(hdz(k,i)+hdz(k+1,i)))+
-     |      gmr ! s13
-          tphdz0(k+1,i) = 2.*tp1(k  ,i)*(0.5*(hdz(k,i)+hdz(k+1,i)))-
-     |      gmr ! s12
-        enddo ! k=lev0,lev1-2
-      enddo ! i=lon0,lon1
-!
-! Upper and lower boundaries:
-      do i=lon0,lon1
-        tphdz1(lev0,i) = 2.*tp1(lev0,i)*
-     |                   (1.5*hdz(lev0,i)-0.5*hdz(lev0+1,i))+gmr
-        tphdz1(lev1,i) = 2.*(2.*tp1(lev1-1,i)-tp1(lev1-2,i))*
-     |                   (1.5*hdz(lev1-1,i)-0.5*hdz(lev1-2,i))+gmr
-        tphdz0(lev0,i) = 2.*(2.*tp1(lev0,i)-tp1(lev0+1,i))*
-     |                   (1.5*hdz(lev0,i)-0.5*hdz(lev0+1,i))-gmr
-        tphdz0(lev1,i) = 2.*tp1(lev1-1,i)*
-     |                   (1.5*hdz(lev1-1,i)-0.5*hdz(lev1-2,i))-gmr
-      enddo ! i=lon0,lon1
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1
+            tphdz1(k,i,lat) = 2.*tp (k,i,lat)*hdzi(k,i,lat)+gmr ! s13
+            tphdz0(k,i,lat) = 2.*tp1(k,i,lat)*hdzi(k,i,lat)-gmr ! s12
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0,lon1
 
-!     call addfld('TPHDZ1',' ',' ',tphdz1,
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('TPHDZ0',' ',' ',tphdz0,
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('TPHDZ1',' ',' ',tphdz1(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('TPHDZ0',' ',' ',tphdz0(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
 ! djint = dj at interfaces:
-      do i=lon0,lon1
-        do k=lev0,lev1-2
-          djint(k+1,i) = 0.5*(dj(k,i,lat)+dj(k+1,i,lat))
-        enddo ! k=lev0,lev1-2
-        djint(lev0,i) = (1.5*dj(lev0  ,i,lat)-0.5*dj(lev0+1,i,lat))
-        djint(lev1,i) = (1.5*dj(lev1-1,i,lat)-0.5*dj(lev1-2,i,lat))
-      enddo ! i=lon0,lon1
-!     call addfld('DJINT' ,' ',' ',djint,
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-2
+            djint(k+1,i,lat) = 0.5*(dj(k,i,lat)+dj(k+1,i,lat))
+          enddo ! k=lev0,lev1-2
+          djint(lev0,i,lat) = 1.5*dj(lev0  ,i,lat)-0.5*dj(lev0+1,i,lat)
+          djint(lev1,i,lat) = 1.5*dj(lev1-1,i,lat)-0.5*dj(lev1-2,i,lat)
+        enddo ! i=lon0,lon1
+!       call addfld('DJINT' ,' ',' ',djint(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
-      call bdotdh(
-     |  djbz(:,lon0:lon1,jm1),djbz(:,:,lat),djbz(:,lon0:lon1,jp1),
-     |  bdotdh_djbz,lon0,lon1,lev0,lev1,lat)
+      call bdotdh(djbz,bdotdh_djbz,lev0,lev1,lon0,lon1,lat0,lat1)
 !
 ! divbz = (DIV(B)+(DH*D*BZ)/(D*BZ) (was s7)
-      do i=lonbeg,lonend
-        do k=lev0,lev1-1
-          divbz(k,i) = 
-     |      dvb(i,lat)+bdotdh_djbz(k,i)/(dj(k,i,lat)*bz(i,lat)**2)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lonbeg,lonend
-
-! Periodic points for divbz apparently not necessary:
-!     call periodic_f2d(divbz,lon0,lon1,nlevs)
-!
-! Set periodic points to zero to avoid NaNS trap:
-      if (lon0==1) divbz(:,lon0:lon0+1) = 0.
-      if (lon1==nlonp4) divbz(:,lon1-1:lon1) = 0.
-!     call addfld('DIVBZ' ,' ',' ',divbz(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            divbz(k,i,lat) = dvb_bz(i,lat)+
+     |        bdotdh_djbz(k,i,lat)/(djbz(k,i,lat)*bz(i,lat))
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+!       call addfld('DIVBZ' ,' ',' ',divbz(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
 ! hdzmbz = (1./(H*DZ)-(DIV(B)+DH*D*BZ/(D*BZ))/(2*BZ))*BZ**2 (was s10)
 ! hdzpbz = (1./(H*DZ)+(DIV(B)+DH*D*BZ/(D*BZ))/(2*BZ))*BZ**2 (was s9 )
 !
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          hdzmbz(k,i) = (hdz(k,i)-0.5*divbz(k,i))*bz(i,lat)**2
-          hdzpbz(k,i) = (hdz(k,i)+0.5*divbz(k,i))*bz(i,lat)**2
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            hdzmbz(k,i,lat) =
+     |        (hdz(k,i,lat)-0.5*divbz(k,i,lat))*bz(i,lat)**2
+            hdzpbz(k,i,lat) =
+     |        (hdz(k,i,lat)+0.5*divbz(k,i,lat))*bz(i,lat)**2
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
 
-!     call addfld('HDZMBZ' ,' ',' ',hdzmbz(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('HDZPBZ' ,' ',' ',hdzpbz(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('HDZMBZ' ,' ',' ',hdzmbz(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('HDZPBZ' ,' ',' ',hdzpbz(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
-! Sum O+ at time n-1 to explicit terms: N(O+)/(2*DT) (N-1) (was s4)
-! Boundary longitudes for optm1_smooth were obtained after first
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1
+            djint_tphdz0(k,i,lat) = djint(k,i,lat)*tphdz0(k,i,lat)
+            djint_tphdz1(k,i,lat) = djint(k,i,lat)*tphdz1(k,i,lat)
+          enddo ! k=lev0,lev1
+          do k=lev0,lev1-1
+            djint_tphdz0_1(k,i,lat) = djint_tphdz0(k+1,i,lat)
+            djint_tphdz1_1(k,i,lat) = djint_tphdz1(k+1,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+!
+! Begin coefficients p_coeff, q_coeff, r_coeff  (s1,s2,s3)
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            diffp(k,i,lat) =   hdzmbz(k,i,lat)*djint_tphdz0  (k,i,lat)
+            diffq(k,i,lat) = -(hdzpbz(k,i,lat)*djint_tphdz0_1(k,i,lat)+
+     |                         hdzmbz(k,i,lat)*djint_tphdz1  (k,i,lat))
+            diffr(k,i,lat) =   hdzpbz(k,i,lat)*djint_tphdz1_1(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('P_COEFF0',' ',' ',
+!    |    diffp(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('Q_COEFF0',' ',' ',
+!    |    diffq(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('R_COEFF0',' ',' ',
+!    |    diffr(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Continue coefficients with vertical ion velocity:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            driftp(k,i,lat) =
+     |        0.5*(wi(k,i,lat)+wi(k+1,i,lat))*0.5*hdz(k,i,lat)
+            driftq(k,i,lat) = -0.5*(wi(k,i,lat)+wi(k+1,i,lat))*6./re
+            driftr(k,i,lat) =
+     |        -0.5*(wi(k,i,lat)+wi(k+1,i,lat))*0.5*hdz(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('P_COEFF1',' ',' ',
+!    |    driftp(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('Q_COEFF1',' ',' ',
+!    |    driftq(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('R_COEFF1',' ',' ',
+!    |    driftr(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Continue coefficients with vertical neutral wind:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-2
+            bdotu1(k+1) = bdotu(k,i,lat)
+          enddo ! k=lev0,lev1-2
+          bdotu1(lev0) = 2.*bdotu(lev0,i,lat)-bdotu(lev0+1,i,lat)
+          do k=lev0,lev1-1
+            windp(k,i,lat) = bz(i,lat)*bdotu1(k)*0.5*hdz(k,i,lat)
+          enddo ! k=lev0,lev1-1
+!
+          do k=lev0,lev1-1
+            windq(k,i,lat) = -bdotu(k,i,lat)*dvb(i,lat)
+          enddo ! k=lev0,lev1-1
+!
+          do k=lev0,lev1-2
+            bdotu1(k) = bdotu(k+1,i,lat)
+          enddo ! k=lev0,lev1-2
+          bdotu1(lev1-1) = 2.*bdotu(lev1-1,i,lat)-bdotu(lev1-2,i,lat)
+          do k=lev0,lev1-1
+            windr(k,i,lat) = -bz(i,lat)*bdotu1(k)*0.5*hdz(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('P_COEFF2',' ',' ',
+!    |    windp(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('Q_COEFF2',' ',' ',
+!    |    windq(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('R_COEFF2',' ',' ',
+!    |    windr(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Additions to Q coefficients:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            p_coeff(k,i,lat) =
+     |        diffp(k,i,lat)+driftp(k,i,lat)+windp(k,i,lat)
+            q_coeff(k,i,lat) =
+     |        diffq(k,i,lat)+driftq(k,i,lat)+windq(k,i,lat)-
+     |        dtx2inv*nstep_sub
+            r_coeff(k,i,lat) =
+     |        diffr(k,i,lat)+driftr(k,i,lat)+windr(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+!
+! Upper boundary condition for O+:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          ubcb = -bz(i,lat)**2*djint_tphdz0(lev1,i,lat) ! t3
+          ubca = -bz(i,lat)**2*djint_tphdz1(lev1,i,lat) ! t2
+!
+! Q = Q+B/A*R
+          q_coeff(lev1-1,i,lat) = q_coeff(lev1-1,i,lat)+
+     |      ubcb/ubca*r_coeff(lev1-1,i,lat)
+!
+! F = F -R/A*PHI
+          ubcrhs(i,lat) = opflux(i,lat)*r_coeff(lev1-1,i,lat)/ubca
+          r_coeff(lev1-1,i,lat) = 0.
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+
+!     do lat=lat0,lat1
+!       call addfld('P_COEFF3',' ',' ',
+!    |    p_coeff(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('Q_COEFF3',' ',' ',
+!    |    q_coeff(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('R_COEFF3',' ',' ',
+!    |    r_coeff(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+
+!       call addfld('QOP2P_OP',' ',' ',qop2p(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('QOP2D_OP',' ',' ',qop2d(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('RK20',' ',' ',rk20(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('RK25',' ',' ',rk25(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+! Sources and sinks (xiop2p and xiop2d are outputs):
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            o2_cm3 = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
+            o1_cm3 = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
+            n2_cm3 = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
+            n2d_cm3 = xnmbar(k,i,lat)*n2d(k,i,lat)*rmassinv_n2d
+!
+            xiop2p(k,i,lat) =
+     |        0.5*(qop2p(k,i,lat)+qop2p(k+1,i,lat))/
+     |        ((rk16+rk17)*n2_cm3+rk18*o1_cm3+
+     |        (rk19(k,i,lat)+rk20(k,i,lat))*ne(k,i,lat)+rk21+rk22)
+!
+            xiop2d(k,i,lat) =
+     |        (0.5*(qop2d(k,i,lat)+qop2d(k+1,i,lat))+
+     |        (rk20(k,i,lat)*ne(k,i,lat)+rk22)*xiop2p(k,i,lat))/
+     |        (rk23*n2_cm3+rk24*o1_cm3+rk26*o2_cm3+
+     |        rk25(k,i,lat)*ne(k,i,lat)+rk27)
+!
+            op_loss(k,i,lat) =
+     |        rk1(k,i,lat)*o2_cm3+rk2(k,i,lat)*n2_cm3+rk10*n2d_cm3
+!
+            q_coeff(k,i,lat) = q_coeff(k,i,lat)-op_loss(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('XIOP2P',' ',' ',xiop2p(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('XIOP2D',' ',' ',xiop2d(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_LOSS_COEF',' ',' ',
+!    |    op_loss(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OP_QOP',' ',' ',qop(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_NE' ,' ',' ',ne(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_O1' ,' ',' ',o1(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_TN' ,' ',' ',tn(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_RK19' ,' ',' ',rk19(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OP_RK25' ,' ',' ',rk25(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Add source term to RHS (explicit terms):
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            op_prod(k,i,lat) =
+     |        0.5*(qop(k,i,lat)+qop(k+1,i,lat))+
+     |        (rk19(k,i,lat)*ne(k,i,lat)+rk21)*xiop2p(k,i,lat)+
+     |        (rk25(k,i,lat)*ne(k,i,lat)+rk27)*xiop2d(k,i,lat)+
+     |        (rk18*xiop2p(k,i,lat)+rk24*xiop2d(k,i,lat))*o1_cm3
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+!
+! Lower boundary condition N(O+) = Q/L:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          q_coeff(lev0,i,lat) = q_coeff(lev0,i,lat)-p_coeff(lev0,i,lat)
+          lbcrhs(i,lat) = 2.*p_coeff(lev0,i,lat)*qop(lev0,i,lat)/
+     |      (1.5*op_loss(lev0,i,lat)-0.5*op_loss(lev0+1,i,lat))
+          p_coeff(lev0,i,lat) = 0.
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+
+!     do lat=lat0,lat1
+!       call addfld('P_COEFF',' ',' ',
+!    |    p_coeff(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('Q_COEFF',' ',' ',
+!    |    q_coeff(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('R_COEFF',' ',' ',
+!    |    r_coeff(lev0:lev1-2,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-2,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+
+      end subroutine prep_oplus
+!-----------------------------------------------------------------------
+      subroutine smooth_oplus(optm1,optm1_smooth,
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
+!
+! Shapiro smoother for O+
+!
+      use cons_module,only: shapiro
+      use input_module,only: nstep_sub
+!
+! Args:
+      integer,intent(in) ::
+     |  lev0,lev1, ! first,last pressure  indices for current task (bot->top)
+     |  lon0,lon1, ! first,last longitude indices for current task (W->E)
+     |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
+!
+! Input fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(in) ::
+     |  optm1      ! O+ at time n-1
+!
+! Output fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(out) ::
+     |  optm1_smooth ! op at time n-1, with shapiro smoother (was s1)
+!
+! Local:
+      integer :: k,i,lat
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0:lat1) ::
+     |  optm1_smooth1 ! op at time n-1, with shapiro smoother (was s1)
+!
+! Save inputs to secondary history file:
+!
+!     do lat=lat0,lat1
+!       call addfld('OPTM1',' ',' ',optm1(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+! Shapiro smoother: optm1 is O+ at time n-1 (optm1_smooth was s1)
+! optm1_smooth will be used in explicit terms below.
+      do lat=lat0,lat1
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            optm1_smooth1(k,i,lat) = optm1(k,i,lat)-
+     |        shapiro/nstep_sub*
+     |        (optm1(k,i,lat+2)+optm1(k,i,lat-2)-
+     |        4.*(optm1(k,i,lat+1)+optm1(k,i,lat-1))+
+     |        6.*optm1(k,i,lat))
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+!       call addfld('OPTM1_SM0' ,' ',' ',
+!    |    optm1_smooth1(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Boundary longitudes for optm1_smooth1 were obtained after first
 ! latitude scan above.
 !
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          optm1_smooth2(k,i,lat) =
-     |      optm1_smooth(k,i,lat)-shapiro/nstep_sub*
-     |      (optm1_smooth(k,i+2,lat)+optm1_smooth(k,i-2,lat)-4.*
-     |      (optm1_smooth(k,i+1,lat)+optm1_smooth(k,i-1,lat))+6.*
-     |       optm1_smooth(k,i,lat))
-        enddo
-      enddo
-      do i=lonbeg,lonend
-        do k=lev0,lev1-1
-          explicit(k,i) = explicit(k,i)-
-     |      optm1_smooth2(k,i,lat)*dtx2inv*nstep_sub
-        enddo ! k=lev0,lev1
-      enddo ! i=lonbeg,lonend
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            optm1_smooth(k,i,lat) = optm1_smooth1(k,i,lat)-
+     |        shapiro/nstep_sub*
+     |        (optm1_smooth1(k,i+2,lat)+optm1_smooth1(k,i-2,lat)-
+     |        4.*(optm1_smooth1(k,i+1,lat)+optm1_smooth1(k,i-1,lat))+
+     |        6.*optm1_smooth1(k,i,lat))
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+!       call addfld('OPTM1_SM1' ,' ',' ',
+!    |    optm1_smooth(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+      end subroutine smooth_oplus
+!-----------------------------------------------------------------------
+      subroutine iterate_oplus(dvb,ubcrhs,lbcrhs,dj,tp,bdotu,
+     |  optm1_smooth,op_prod,ui,vi,scht,p_coeff,q_coeff,r_coeff,
+     |  op,opout,diffj,diffexp,vdotn_h,bdotdh_bvel,
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
+!
+! Update O+ ion at 3d task subdomain.
+! Outputs are opout, diffj, diffexp, vdotn_h, bdotdh_bvel,
+! all other args are input.
+!
+      use params_module,only: nlonp4,dz
+      use cons_module,only: rmass_op,gask,grav,re,cs,dphi,dlamda,dtx2inv
+      use input_module,only: nstep_sub
+      use magfield_module,only: bz,bmod2 ! (nlonp4,-1:nlat+2)
+      use mpi_module,only: mp_periodic_f3d,mp_polelats_f3d,
+     |  mp_bndlats_f3d,mp_bndlons_f3d
+      use addfld_module,only: addfld
+!
+! Args:
+      integer,intent(in) ::
+     |  lev0,lev1, ! first,last pressure  indices for current task (bot->top)
+     |  lon0,lon1, ! first,last longitude indices for current task (W->E)
+     |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
+!
+! Input fields (full 2d task subdomain):
+      real,dimension(lon0-2:lon1+2,lat0-2:lat1+2),intent(in) ::
+     |  dvb,        ! output of sub divb
+     |  ubcrhs,lbcrhs
+!
+! Input fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(in) ::
+     |  dj,          ! diffusion coefficients (s13,s14,s15)
+     |  tp,          ! Plasma temperature (te+ti)
+     |  bdotu,       ! was s7 (B.U)
+     |  optm1_smooth,! op at time n-1, with shapiro smoother (was s1)
+     |  op_prod,
+     |  ui,vi,       ! zonal, and meridional ion velocities
+     |  scht,        ! scale height
+     |  p_coeff,q_coeff,r_coeff, ! coefficients for tridiagonal solver (s1,s2,s3)
+     |  op           ! O+ ion
+!
+! Output fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(out) ::
+     |  opout,    ! O+ output for next timestep
+     |  diffj,    ! (D/(H*DZ)*2.*TP+M*G/R)*N(O+) (s7,s8,s9)
+     |  diffexp,vdotn_h,bdotdh_bvel
+!
+! Local:
+      integer :: k,i,lat,ier,nlevs
+      real :: mgr
+      real,dimension(lev0:lev1) :: dtpop,dbdotdh_opj
+      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
+     |  bdzdvb_op,        ! was s7
+     |  explicit,         ! was s4
+     |  bdotdh_op,        ! (b(h)*del(h))*phi
+     |  bdotdh_diff       ! (b(h)*del(h))*phi
+!
+! Local fields at 3d subdomain (must be 3d to bridge latitude scans):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
+     |  bvel,tpop,op_bmod2,bdotdh_opj ! (b(h)*del(h))*phi
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) :: tmpf3d
+!
+#ifdef VT
+!     code = 113 ; state = 'oplus' ; activity='ModelCode'
+      call vtbegin(113,ier)
+#endif
+!
+! Number of pressure levels (this will equal nlevp1):
+      nlevs = lev1-lev0+1 ! for bndlons calls
+!
+! Save inputs to secondary history file:
+!
+!     do lat=lat0,lat1
+!       call addfld('OP_OPLUS',' ',' ',op(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('UI_OP',' ',' ',ui(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('VI_OP',' ',' ',vi(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+! bvel @ j   = (B.U)*N(O+)      (J) (was s7)
+!
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            bvel(k,i,lat) = bdotu(k,i,lat)*op(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+!     do lat=lat0,lat1
+!       call addfld('BVEL_J',' ',' ',bvel(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+! Plasma temperature times O+
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            tpop(k,i,lat) = tp(k,i,lat)*op(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+!     do lat=lat0,lat1
+!       call addfld('TPJ','TP after times OP',' ',
+!    |    tpop(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+! Evaluates ans = (d/(h*dz)*tp+m*g/r)*en
+!
+      mgr = rmass_op*grav/gask
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0+1,lev1-2
+            dtpop(k) = (tpop(k+1,i,lat)-tpop(k-1,i,lat))/2.
+          enddo ! k=lev0+1,lev1-2
+!
+! Upper and lower boundaries:
+          dtpop(lev1-1) = tpop(lev1-1,i,lat)-tpop(lev1-2,i,lat)
+          dtpop(lev0) = tpop(lev0+1,i,lat)-tpop(lev0,i,lat)
+!
+          do k=lev0,lev1-1
+            diffj(k,i,lat) = 1./(scht(k,i,lat)*dz)*2.*dtpop(k)+
+     |        mgr*op(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+
+!     do lat=lat0,lat1
+!       call addfld('DIFFJ','DIFFJ after diffus',' ',
+!    |    diffj(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+! bdotdh_op = (B(H).DEL(H))*(D/(H*DZ)*TP+M*G/R)*N(O+)
+! then bdotdh_op = d*bz*bdotdh_op
+!
+      call bdotdh(diffj,bdotdh_op,lev0,lev1,lon0,lon1,lat0,lat1)
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            bdotdh_op(k,i,lat) =
+     |        dj(k,i,lat)*bz(i,lat)*bdotdh_op(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('BDOTDH_1',' ',' ',
+!    |    bdotdh_op(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! bdotdh_opj   = (B(H).DEL(H))*2.*TP*N(O+)      (J)
+!
+      call bdotdh(2.*tpop,bdotdh_opj(:,lon0:lon1,lat0:lat1),
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            bdotdh_opj(k,i,lat) = bdotdh_opj(k,i,lat)*dj(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('BDOTDH_2',' ',' ',
+!    |    bdotdh_opj(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            op_bmod2(k,i,lat) = op(k,i,lat)/bmod2(i,lat)**2
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            tmpf3d(k,i,lat,1) = bdotdh_opj(k,i,lat)
+            tmpf3d(k,i,lat,2) = op_bmod2(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+      call mp_polelats_f3d(tmpf3d(:,lon0:lon1,:,:),
+     |  lev0,lev1,lon0,lon1,lat0,lat1,2,(/1.,1./))
+      call mp_bndlats_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2)
+      call mp_bndlons_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2,0)
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            bdotdh_opj(k,i,lat) = tmpf3d(k,i,lat,1)
+            op_bmod2(k,i,lat) = tmpf3d(k,i,lat,2)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+!
+! bdotdh_opj = (B(H).DEL(H))*D*(B(H).DEL(H))*2.*TP*N(O+)   (J)
+! Note bdotdh_opj longitude dimension is lon-2:lon+2. bdotdh_diff
+!   is returned. (periodic points apparently not necessary for
+!   bdotdh_diff)
+!
+      call bdotdh(bdotdh_opj,bdotdh_diff,lev0,lev1,lon0,lon1,lat0,lat1)
+
+!     do lat=lat0,lat1
+!       call addfld('BDOT_J'  ,' ',' ',
+!    |    bdotdh_opj(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('BDOT_DIF',' ',' ',
+!    |    bdotdh_diff(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+! bdzdvb_op = (BZ*D/(H*DZ)+DIV(*B))*S2
+!
+! Evaluates (bz*d/(h*dz)+divb)*phi
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0+1,lev1-2
+            dbdotdh_opj(k) =
+     |        (bdotdh_opj(k+1,i,lat)-bdotdh_opj(k-1,i,lat))/2.
+          enddo ! k=lev0+1,lev1-2
+!
+! Upper and lower boundaries:
+          dbdotdh_opj(lev1-1) =
+     |      bdotdh_opj(lev1-1,i,lat)-bdotdh_opj(lev1-2,i,lat)
+          dbdotdh_opj(lev0) =
+     |      bdotdh_opj(lev0+1,i,lat)-bdotdh_opj(lev0,i,lat)
+!
+          do k=lev0,lev1-1
+            bdzdvb_op(k,i,lat) =
+     |        bz(i,lat)/(scht(k,i,lat)*dz)*dbdotdh_opj(k)+
+     |        dvb(i,lat)*bdotdh_opj(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('BDZDVB',' ',' ',bdzdvb_op(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Collect explicit terms:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            diffexp(k,i,lat) =
+     |        bdzdvb_op(k,i,lat)+bdotdh_diff(k,i,lat)+bdotdh_op(k,i,lat)
+            explicit(k,i,lat) = -diffexp(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('EXPLIC0',' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+
+!     do lat=lat0,lat1
+!       call addfld('UI_VEL',' ',' ',ui(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('VI_VEL',' ',' ',vi(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
+!
+      call bdotdh(bvel,bdotdh_bvel(:,lon0:lon1,lat0:lat1),
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
+!
+! Note if input flag DYNAMO<=0, then ui,vi,wi velocities will be zero.
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            vdotn_h(k,i,lat) = bmod2(i,lat)**2/(2.*re)*
+     |        (1./(cs(lat)*dlamda)*
+     |        0.5*(ui(k,i,lat)+ui(k+1,i,lat))*
+     |        (op_bmod2(k,i+1,lat)-op_bmod2(k,i-1,lat))+
+!
+     |        1./dphi*
+     |        0.5*(vi(k,i,lat)+vi(k+1,i,lat))*
+     |        (op_bmod2(k,i,lat+1)-op_bmod2(k,i,lat-1)))
+!
+            explicit(k,i,lat) = explicit(k,i,lat)+
+     |        vdotn_h(k,i,lat)+bdotdh_bvel(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+
+!       call addfld('EXPLIC1',' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Sum O+ at time n-1 to explicit terms: N(O+)/(2*DT) (N-1) (was s4)
+!
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            explicit(k,i,lat) = explicit(k,i,lat)-
+     |        optm1_smooth(k,i,lat)*dtx2inv*nstep_sub
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0,lon1
 
 !     call addfld('OPTM1_SM1' ,' ',' ',
 !    |  optm1_smooth(lev0:lev1-1,lon0:lon1,lat),
 !    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('EXPLIC2' ,' ',' ',explicit(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-! 
-! Begin coefficients p_coeff, q_coeff, r_coeff  (s1,s2,s3)
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          diffp(k,i,lat) =   hdzmbz(k,i)*djint(k  ,i)*tphdz0(k  ,i)
-          diffq(k,i,lat) = -(hdzpbz(k,i)*djint(k+1,i)*tphdz0(k+1,i)+
-     |                       hdzmbz(k,i)*djint(k  ,i)*tphdz1(k  ,i))
-          diffr(k,i,lat) =   hdzpbz(k,i)*djint(k+1,i)*tphdz1(k+1,i)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-
-!     call addfld('P_COEFF0',' ',' ',diffp(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('Q_COEFF0',' ',' ',diffq(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('R_COEFF0',' ',' ',diffr(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! Continue coefficients with vertical ion velocity:
-      do i=lon0,lon1
-        do k=lev0,lev1-2
-          driftp(k+1,i,lat) =
-     |      0.5*(wi(k+1,i,lat)+wi(k+2,i,lat))*0.5*hdz(k+1,i)
-          driftq(k,i,lat) = -0.5*(wi(k,i,lat)+wi(k+1,i,lat))*6./re
-          driftr(k,i,lat) =
-     |      -0.5*(wi(k,i,lat)+wi(k+1,i,lat))*0.5*hdz(k,i)
-        enddo ! k=lev0,lev1-2
-      enddo ! i=lon0,lon1
-!
-! Upper and lower boundaries:
-      do i=lon0,lon1
-        driftp(lev0,i,lat) = 
-     |    0.5*(wi(lev0,i,lat)+wi(lev0+1,i,lat))*0.5*hdz(lev0,i)
-        driftq(lev1-1,i,lat) =
-     |    -0.5*(wi(lev1,i,lat)+wi(lev1-1,i,lat))*6./re
-        driftr(lev1-1,i,lat) =
-     |    -0.5*(wi(lev1,i,lat)+wi(lev1-1,i,lat))*0.5*hdz(lev1-1,i)
-      enddo ! i=lon0,lon1
-
-!     call addfld('P_COEFF1',' ',' ',driftp(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('Q_COEFF1',' ',' ',driftq(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('R_COEFF1',' ',' ',driftr(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! Continue coefficients with vertical neutral wind:
-      do i=lon0,lon1
-        do k=lev0,lev1-2
-          windp(k+1,i,lat) = bz(i,lat)*bdotu(k,i,lat)*0.5*hdz(k+1,i)
-          windq(k,i,lat) = -bdotu(k,i,lat)*dvb(i,lat)*bz(i,lat)
-          windr(k,i,lat) = -bz(i,lat)*bdotu(k+1,i,lat)*0.5*hdz(k,i)
-        enddo ! k=lev0,lev1-2
-      enddo ! i=lon0,lon1
-!
-! Upper and lower boundaries:
-      do i=lon0,lon1
-        windp(lev0,i,lat) = bz(i,lat)*
-     |    (2.*bdotu(lev0,i,lat)-bdotu(lev0+1,i,lat))*0.5*hdz(lev0,i)
-        windq(lev1-1,i,lat) = -bdotu(lev1-1,i,lat)*dvb(i,lat)*bz(i,lat)
-        windr(lev1-1,i,lat) = bz(i,lat)*
-     |   (2.*bdotu(lev1-1,i,lat)-bdotu(lev1-2,i,lat))*0.5*hdz(lev1-1,i)
-      enddo ! i=lon0,lon1
-
-!     call addfld('P_COEFF2',' ',' ',windp(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('Q_COEFF2',' ',' ',windq(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('R_COEFF2',' ',' ',windr(lev0:lev1-1,:,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! Additions to Q coefficients:
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          p_coeff(k,i) = diffp(k,i,lat)+driftp(k,i,lat)+windp(k,i,lat)
-          q_coeff(k,i) = diffq(k,i,lat)+driftq(k,i,lat)+windq(k,i,lat)
-     |      -dtx2inv*nstep_sub
-          r_coeff(k,i) = diffr(k,i,lat)+driftr(k,i,lat)+windr(k,i,lat)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
+!       call addfld('EXPLIC2' ,' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
 ! Upper boundary condition for O+:
-      do i=lon0,lon1
-        ubca(i) = 0.
-        ubcb(i) = -bz(i,lat)**2*djint(lev1,i)*tphdz0(lev1,i)-ubca(i) ! t3
-        ubca(i) = -bz(i,lat)**2*djint(lev1,i)*tphdz1(lev1,i)+ubca(i) ! t2
-!
-! Q = Q+B/A*R
-        q_coeff(lev1-1,i) = q_coeff(lev1-1,i)+ubcb(i)/ubca(i)*
-     |    r_coeff(lev1-1,i) 
+      do lat=lat0,lat1
+        do i=lon0,lon1
 !
 ! F = F -R/A*PHI
-        explicit(lev1-1,i) = explicit(lev1-1,i)-opflux(i,lat)*
-     |    r_coeff(lev1-1,i)/ubca(i)
-        r_coeff(lev1-1,i) = 0.
-      enddo ! i=lon0,lon1
+          explicit(lev1-1,i,lat) = explicit(lev1-1,i,lat)-ubcrhs(i,lat)
+        enddo ! i=lon0,lon1
 
-!     call addfld('EXPLIC3',' ',' ',explicit(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('P_COEFF2',' ',' ',p_coeff(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('Q_COEFF2',' ',' ',q_coeff(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('R_COEFF2',' ',' ',r_coeff(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-
-!     call addfld('QOP2P_OP',' ',' ',qop2p(:,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('QOP2D_OP',' ',' ',qop2d(:,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('RK20',' ',' ',rk20(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('RK25',' ',' ',rk25(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!
-! Sources and sinks (xiop2p and xiop2d are outputs):
-!
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          xiop2p(k,i,lat) = 
-     |      0.5*(qop2p(k,i,lat)+qop2p(k+1,i,lat))/((xnmbar(k,i,lat)*
-     |      ((rk16+rk17)*n2(k,i,lat)*rmassinv_n2+
-     |      rk18*o1(k,i,lat)*rmassinv_o1))+
-     |      (rk19(k,i,lat)+rk20(k,i,lat))*ne(k,i,lat)+rk21+rk22)
-! 
-          xiop2d(k,i,lat) = 
-     |      (0.5*(qop2d(k,i,lat)+qop2d(k+1,i,lat))+(rk20(k,i,lat)*
-     |      ne(k,i,lat)+rk22)*xiop2p(k,i,lat))/((xnmbar(k,i,lat)*
-     |      (rk23*n2(k,i,lat)*rmassinv_n2+rk24*
-     |      o1(k,i,lat)*rmassinv_o1+rk26*o2(k,i,lat)*rmassinv_o2))+
-     |      rk25(k,i,lat)*ne(k,i,lat)+rk27)
-! 
-          op_loss(k,i,lat) = 
-     |      xnmbar(k,i,lat)*(rk1(k,i,lat)*o2(k,i,lat)*rmassinv_o2+
-     |      rk2(k,i,lat)*n2(k,i,lat)*rmassinv_n2+rk10*
-     |      n2d(k,i,lat)*rmassinv_n2d)
-!
-          q_coeff(k,i) = q_coeff(k,i)-op_loss(k,i,lat)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-
-!     call addfld('XIOP2P',' ',' ',xiop2p(lev0:lev1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('XIOP2D',' ',' ',xiop2d(lev0:lev1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('OP_LOSS',' ',' ',op_loss(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('OP_QOP',' ',' ',qop(lev0:lev1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('OP_NE' ,' ',' ',ne(lev0:lev1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('OP_O1' ,' ',' ',o1(lev0:lev1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('OP_TN' ,' ',' ',tn(lev0:lev1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     call addfld('OP_RK19' ,' ',' ',rk19(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('OP_RK25' ,' ',' ',rk25(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('EXPLIC3',' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
 ! Add source term to RHS (explicit terms):
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-          op_prod(k,i) =
-     |      0.5*(qop(k,i,lat)+qop(k+1,i,lat))+(rk19(k,i,lat)*
-     |      ne(k,i,lat)+rk21)*
-     |      xiop2p(k,i,lat)+(rk25(k,i,lat)*ne(k,i,lat)+rk27)*
-     |      xiop2d(k,i,lat)+(rk18*xiop2p(k,i,lat)+rk24*xiop2d(k,i,lat))*
-     |      o1(k,i,lat)*rmassinv_o1*xnmbar(k,i,lat)
-          explicit(k,i) = explicit(k,i)-op_prod(k,i)
-        enddo ! k=lev0,lev1-1
-      enddo ! i=lon0,lon1
-!     call addfld('EXPLIC4',' ',' ',explicit(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            explicit(k,i,lat) = explicit(k,i,lat)-op_prod(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+!       call addfld('EXPLIC4',' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
 ! Lower boundary condition N(O+) = Q/L:
-      do i=lon0,lon1
-        q_coeff(lev0,i) = q_coeff(lev0,i)-p_coeff(lev0,i) 
-        explicit(lev0,i) = explicit(lev0,i)-2.*p_coeff(lev0,i)*
-     |    qop(lev0,i,lat)/
-     |    (1.5*op_loss(lev0,i,lat)-0.5*op_loss(lev0+1,i,lat))
-        p_coeff(lev0,i) = 0.
-      enddo ! i=lon0,lon1
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          explicit(lev0,i,lat) = explicit(lev0,i,lat)-lbcrhs(i,lat)
+        enddo ! i=lon0,lon1
 
-!     call addfld('P_COEFF',' ',' ',p_coeff(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('Q_COEFF',' ',' ',q_coeff(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     call addfld('R_COEFF',' ',' ',r_coeff(lev0:lev1-2,:),
-!    |  'lev',lev0,lev1-2,'lon',lon0,lon1,lat)
-!     call addfld('EXPLIC5',' ',' ',explicit(lev0:lev1-1,:),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('EXPLIC5',' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
 ! Tridiagonal solver returns updated O+ in opout (all other args are input):
 !     subroutine trsolv(a,b,c,f,x,lev0,lev1,k1,k2,lon0,lon1,lonmax,lat,
 !    |  idebug)
 !
-      call trsolv(p_coeff,q_coeff,r_coeff,explicit,
-     |  opout(:,lon0:lon1,lat),lev0,lev1,lev0,lev1-1,lon0,lon1,nlonp4,
-     |  lat,0)
+      do lat=lat0,lat1
+        call trsolv(
+     |    p_coeff(:,lon0:lon1,lat),
+     |    q_coeff(:,lon0:lon1,lat),
+     |    r_coeff(:,lon0:lon1,lat),
+     |    explicit(:,lon0:lon1,lat),
+     |    opout(:,lon0:lon1,lat),
+     |    lev0,lev1,lev0,lev1-1,lon0,lon1,nlonp4,lat,0)
 !
-!     call addfld('OP_SOLV',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OP_SOLV',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 
-        if (debug) 
-     |    write(6,"('oplus end third lat scan: lat=',i3)") lat
       enddo ! lat=lat0,lat1
-!------------------------ End third latitude scan ---------------------
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            dopdt(k,i) = dtx2inv*nstep_sub*
-     |        (opout(k,i,lat)-optm1_smooth2(k,i,lat))
-            op_loss_out(k,i) = op_loss(k,i,lat)*opout(k,i,lat)
-          enddo
-          do k=lev0+1,lev1-1
-            diffsum (k,i) = diffexp(k,i,lat)+
-     |        diffp (k,i,lat)*opout(k-1,i,lat)+
-     |        diffq (k,i,lat)*opout(k  ,i,lat)+
-     |        diffr (k,i,lat)*opout(k+1,i,lat)
-            driftsum(k,i) = -vdotn_h(k,i,lat)+
-     |        driftp(k,i,lat)*opout(k-1,i,lat)+
-     |        driftq(k,i,lat)*opout(k  ,i,lat)+
-     |        driftr(k,i,lat)*opout(k+1,i,lat)
-            windsum (k,i) = -bdotdh_bvel(k,i,lat)+
-     |        windp (k,i,lat)*opout(k-1,i,lat)+
-     |        windq (k,i,lat)*opout(k  ,i,lat)+
-     |        windr (k,i,lat)*opout(k+1,i,lat)
-          enddo
-        enddo
-        call addfld('DOPDT','O+ changing rate','cm-3s-1',
-     |    dopdt(lev0:lev1-1,:),'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-        call addfld('OP_PROD','O+ production','cm-3s-1',
-     |    op_prod(lev0:lev1-1,:),'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-        call addfld('OP_LOSS','O+ loss','cm-3s-1',
-     |    -op_loss_out(lev0:lev1-1,:),
-     |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-        call addfld('OP_DIFF',
-     |    'O+ transport due to ambipolar diffusion','cm-3s-1',
-     |    diffsum(lev0+1:lev1-1,:),
-     |    'lev',lev0+1,lev1-1,'lon',lon0,lon1,lat)
-        call addfld('OP_DRIFT',
-     |    'O+ transport due to ion drift','cm-3s-1',
-     |     driftsum(lev0+1:lev1-1,:),
-     |    'lev',lev0+1,lev1-1,'lon',lon0,lon1,lat)
-        call addfld('OP_WIND',
-     |    'O+ transport due to neutral wind','cm-3s-1',
-     |    windsum(lev0+1:lev1-1,:),
-     |    'lev',lev0+1,lev1-1,'lon',lon0,lon1,lat)
-      enddo
 !
-! Filter updated O+:
-! 
-      call filter_op(opout(:,lon0:lon1,lat0:lat1),
-     |  lev0,lev1,lon0,lon1,lat0,lat1,'OPLUS')
+! Periodic points for outputs:
+        call mp_periodic_f3d(opout(:,lon0:lon1,lat0:lat1),
+     |    lev0,lev1,lon0,lon1,lat0,lat1,1)
 !
-!----------------------- Begin fourth latitude scan ---------------------
-      do lat=lat0,lat1
-        if (debug) 
-     |    write(6,"('oplus begin fourth lat scan: lat=',i3)") lat
+#ifdef VT
+!     code = 113 ; state = 'oplus' ; activity='ModelCode'
+      call vtend(113,ier)
+#endif
+      end subroutine iterate_oplus
+!-----------------------------------------------------------------------
+      subroutine post_oplus(op,optm1,opout,optm1out,
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
-!     call addfld('OP_FILT',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+! Post-processing time smoothing.
+! This is called after filter_op
+!
+      use cons_module,only: dtsmooth,dtsmooth_div2
+!
+! Args:
+      integer,intent(in) ::
+     |  lev0,lev1, ! first,last pressure  indices for current task (bot->top)
+     |  lon0,lon1, ! first,last longitude indices for current task (W->E)
+     |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
+!
+! Input fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(in) ::
+     |  op,         ! O+ ion
+     |  optm1       ! O+ at time n-1
+!
+! Output fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(inout) ::
+     |  opout     ! O+ output for next timestep
+!
+! Output fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(out) ::
+     |  optm1out  ! O+ output for time n-1
+!
+! Local:
+      integer :: k,i,lat
 !
 ! Time smoothing:
 !
@@ -924,355 +1274,197 @@
 ! optm1(k,i,lat)   : O+ at current latitude and time n-1.
 ! opout(k,i,lat)   : New O+ at current latitude and time.
 !
-      do i=lon0,lon1
-        do k=lev0,lev1-1      
-          optm1out(k,i,lat) = dtsmooth*op(k,i,lat)+dtsmooth_div2*
-     |      (optm1(k,i,lat)+opout(k,i,lat))
-        enddo ! k=lev0,lev1-1      
-      enddo ! i=lon0,lon1
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            optm1out(k,i,lat) = dtsmooth*op(k,i,lat)+
+     |        dtsmooth_div2*(optm1(k,i,lat)+opout(k,i,lat))
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
 !
 ! Upper boundary:
-      opout(lev1,:,lat) = 0.
-      optm1out(lev1,:,lat) = 0.
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          opout(lev1,i,lat) = 0.
+          optm1out(lev1,i,lat) = 0.
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
 !
 ! Insure global non-negative O+:
-      do i=lon0,lon1
-        do k=lev0,lev1-1      
-          if (opout(k,i,lat)    < 0.) opout(k,i,lat)    = 0.
-          if (optm1out(k,i,lat) < 0.) optm1out(k,i,lat) = 0.
-        enddo ! k=lev0,lev1-1      
-      enddo ! i=lon0,lon1
-!
-! 12/4/14 btf: Enforce O+ minimum.
-! Opfloor is Stan's "smooth floor" (product of two Gaussians, 
-!   dependent on latitude and pressure level) (opmin=1000.0):
-!
-! 2024/08 Haonan Wu:
-!   Change the altitude distribution of O+ minimum from Gaussian to logistic,
-!   also change the latitude distribution based on magnetic latitudes
-!   instead of geographic latitudes
-!
-      if (opfloor/=0. .and. oprate/=0. .and.
-     |    oplev/=spval .and. oplatwidth/=0.) then
-        do k=lev0,lev1-1
-          do i=lon0,lon1
-            opmin = opfloor*exp(-(rlatm(i,lat)*rtd/oplatwidth)**2)
-     |        /(1+exp(-oprate*(zpmid(k)-oplev)))
-            if (opout(k,i,lat) < opmin) then
-              opout(k,i,lat) = opmin
-            endif ! opout < opmin
-          enddo ! i=lon0,lon1
-        enddo ! k=lev0,lev1-1
-      endif
-!
-! End fourth and final latitude scan:
-      enddo ! lat=lat0,lat1
-!
-! Periodic points for outputs:
-      call mp_periodic_f3d(opout(:,lon0:lon1,lat0:lat1),
-     |  lev0,lev1,lon0,lon1,lat0,lat1,1)
-      call mp_periodic_f3d(optm1out(:,lon0:lon1,lat0:lat1),
-     |  lev0,lev1,lon0,lon1,lat0,lat1,1)
-!
-      call mp_polelats_f3d(opout(:,lon0:lon1,:),
-     |  lev0,lev1,lon0,lon1,lat0,lat1,1,(/1./))
-      call mp_bndlats_f3d(opout,nlevs,lon0,lon1,lat0,lat1,1)
-      call mp_bndlons_f3d(opout,nlevs,lon0,lon1,lat0,lat1,1,0)
-!
-      call mp_polelats_f3d(optm1out(:,lon0:lon1,:),
-     |  lev0,lev1,lon0,lon1,lat0,lat1,1,(/1./))
-      call mp_bndlats_f3d(optm1out,nlevs,lon0,lon1,lat0,lat1,1)
-      call mp_bndlons_f3d(optm1out,nlevs,lon0,lon1,lat0,lat1,1,0)
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            if (opout(k,i,lat)    < 0.) opout(k,i,lat)    = 0.
+            if (optm1out(k,i,lat) < 0.) optm1out(k,i,lat) = 0.
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
 !
 ! Save outputs on secondary history for diagnostics:
 !     do lat=lat0,lat1
 !       call addfld('OPOUT',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('OPOUTM1',' ',' ',optm1out(lev0:lev1-1,lon0:lon1,
-!    |    lat),'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OPOUTM1',' ',' ',
+!    |    optm1out(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !     enddo ! lat=lat0,lat1
-#ifdef VT
-!     code = 113 ; state = 'oplus' ; activity='ModelCode'
-      call vtend(113,ier)
-#endif
-      if (debug) 
-     |  write(6,"('oplus returning.')")
-      end subroutine oplus
+      end subroutine post_oplus
 !-----------------------------------------------------------------------
-      subroutine oplus_flux(opflux,lon0,lon1,lat0,lat1)
-!
-! Calculate O+ number flux in opflux for sub oplus (was sub opflux).
-!
-      use cons_module,only: pi,rtd
-      use chapman_module,only: chi     ! was t2 in old sub opflux
-      use magfield_module,only: rlatm
-!
-! Args:
-      integer,intent(in) :: lon0,lon1,lat0,lat1
-      real,intent(out) :: opflux(lon0:lon1,lat0:lat1)
-!
-! Local:
-      integer :: i,lat
-      real,parameter ::
-     |  phid =  2.0e8,
-     |  phin = -2.0e8,
-     |  ppolar = 0.
-      real :: a(lon0:lon1)   ! was t3 ("a" needs a better name)
-      real :: fed(lon0:lon1) ! was t4
-      real :: fen(lon0:lon1) ! was t5
-!
-! Latitude scan:
-      do lat=lat0,lat1
-!
-! Longitude loop:
-        do i=lon0,lon1
-!
-! Change upper boundary flux as electron heat flux in settei
-          if (abs(rlatm(i,lat)) >= pi/4.5) then
-            a(i) = 1.
-          elseif (abs(rlatm(i,lat)) <= pi/18.) then
-            a(i) = 0.
-          else
-            a(i) = .5*(1.+cos(abs(rlatm(i,lat))*6.-pi*4./3.))
-          endif
-          fed(i) = phid*a(i)
-          fen(i) = phin*a(i)
-          if (chi(i,lat)-0.5*pi >= 0.) then
-            opflux(i,lat) = fen(i)
-          else
-            opflux(i,lat) = fed(i)
-          endif
-          if ((chi(i,lat)*rtd-80.)*(chi(i,lat)*rtd-100.) < 0.) 
-     |      opflux(i,lat) = .5*(fed(i)+fen(i))+.5*(fed(i)-fen(i))*
-     |        cos(pi*(chi(i,lat)*rtd-80.)/20.)
-!
-! Add ppolar if magnetic latitude >= 60 degrees:
-          if (abs(rlatm(i,lat))-pi/3. >= 0.) 
-     |      opflux(i,lat) = opflux(i,lat)+ppolar
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
-!
-      end subroutine oplus_flux
-!-----------------------------------------------------------------------
-      subroutine divb(dvb,lon0,lon1,lat0,lat1)
-      use cons_module,only: cs,dlamda,dphi,re  
-!
-! Evaluate divergence of B, the unit magnetic field vector.
-!
-! Args:
-      integer,intent(in) :: lon0,lon1,lat0,lat1 
-      real,intent(out) :: dvb(lon0:lon1,lat0:lat1)
-!
-! Local:
-      integer :: lonbeg,lonend,i,lat,jm1,jp1
-!
-      lonbeg = lon0
-      if (lon0==1) lonbeg = 3
-      lonend = lon1
-      if (lon1==nlonp4) lonend = lon1-2
-!
-      do lat=lat0,lat1
-        jm1 = lat-1
-        jp1 = lat+1
-        dvb(:,lat) = 0.
-        do i=lonbeg,lonend
-          dvb(i,lat) = (((bx(i+1,lat)-bx(i-1,lat))/(2.*dlamda)+
-     |      (cs(jp1)*by(i,jp1)-cs(jm1)*by(i,jm1))/(2.*dphi))/
-     |      cs(lat)+2.*bz(i,lat))/re
-        enddo ! i=lonbeg,lonend
-      enddo ! lat=lat0,lat1
-!
-      end subroutine divb
-!-----------------------------------------------------------------------
-      subroutine rrk(rms,ps1,ps2,he,n2,tr,ans,vni,
-     |  lon0,lon1,lev0,lev1)
-!
-! Returns ambipolar diffusion coefficient in ans and vni.
-!
-      use params_module,only: zpmid,spval
-      use cons_module,only: rmassinv_o2,rmassinv_o1,rmassinv_n2,
-     |  rmassinv_he
-      use input_module,only: colfac,opdiffcap,opdiffrate,opdifflev
-      use init_module,only: istep
-!
-! Args:
-      integer,intent(in) :: lon0,lon1,lev0,lev1
-      real,dimension(lev0:lev1,lon0:lon1),intent(in) ::
-     |  rms,ps1,ps2,he,n2,tr
-      real,dimension(lev0:lev1,lon0:lon1),intent(out) :: ans,vni
-!
-! Local:
-      integer :: k,i
-      real :: opdiffmax
-!
-      do i=lon0,lon1
-        do k=lev0,lev1-1
-!
-! 8/28/13 btf: Use n2=1-o2-o-he, and include O+/He collision rate from Wenbin:
-!
-          vni(k,i) = 18.1*ps1(k,i)*rmassinv_o2+
-     |      ps2(k,i)*rmassinv_o1*sqrt(tr(k,i))*
-     |      (1.-0.064*alog10(tr(k,i)))**2*colfac+
-     |      3.6*he(k,i)*rmassinv_he+18.6*n2(k,i)*rmassinv_n2
-          ans(k,i) = 1.42E17/(rms(k,i)*vni(k,i))
-          vni(k,i) = 16*3.53E-11*vni(k,i)
-        enddo ! k=lev0,lev1
-      enddo ! i=lon0,lon1
-!
-! 1/30/16 btf:
-! Cap ambipolar diffusion coefficient. Namelist parameter OPDIFFCAP.
-! This was tested with various values (1.5e8, 3e8, 6e8, 8e8),
-! and was found to improve numerical stability in some storm cases, 
-! for example the November, 2003 and July, 2000 storms, with Weimer
-! potential model and IMF/OMNI data. Both of these cases generally 
-! will not complete if timestep is longer than 10 sec. The Nov, 2003
-! may succeed with opdiffcap turned off, but the July, 2000 
-! "Bastille day storm" will succeed only with step=10 and opdiffcap=6.e8.
-!
-! 2024/08 Haonan Wu:
-!   Change the altitude distribution of maximum O+ diffusion flux
-!   from Gaussian to logistic based on input parameters
-!   this may help stabilize the model in some storm cases
-!   which needs a steeper cap during the main phase
-!   but also needs a smoother cap during the recovery phase
-!
-      if (opdiffcap /= 0. .and. opdiffrate /= 0 .and.
-     |    opdifflev /= spval) then ! default is off
-        if (istep==1) write(6,"('oplus rrk: opdiffcap = ',es12.4)") 
-     |    opdiffcap
-!       where(ans(:,:) > opdiffcap)
-!         ans(:,:) = opdiffcap
-!       endwhere
-        do k=lev0,lev1-1
-          opdiffmax = opdiffcap/
-     |      (1+exp(opdiffrate*(zpmid(k)-opdifflev)))
-          do i=lon0,lon1
-            if (ans(k,i) > opdiffmax) ans(k,i) = opdiffmax
-          enddo
-        enddo
-      endif
-
-      end subroutine rrk
-!-----------------------------------------------------------------------
-      subroutine diffus(tp,en,hj,ans,lon0,lon1,lev0,lev1)
-!
-! Evaluates ans = (d/(h*dz)*tp+m*g/r)*en
-!
-      use cons_module,only: rmass_op,grav,gask
-!
-! Args:
-      integer :: lon0,lon1,lev0,lev1
-      real,dimension(lev0:lev1,lon0:lon1),intent(in) :: tp,en,hj
-      real,dimension(lev0:lev1,lon0:lon1),intent(out) :: ans
-!
-! Local:
-      integer :: k,i,k1,k2
-      real :: mgr
-!
-      mgr = rmass_op*grav/gask
-      do i=lon0,lon1
-        do k=lev0,lev1-2
-          k1 = k+1
-          k2 = k+2
-          ans(k1,i) = 1./(2.*hj(k1,i)*dlev)*(tp(k2,i)*en(k2,i)-
-     |      tp(k,i)*en(k,i))+mgr*en(k1,i)
-        enddo
-      enddo
-!
-! Upper and lower boundaries:
-      k1 = lev1-1
-      k2 = lev1-2
-      do i=lon0,lon1
-        ans(k1,i) = 1./(hj(k1,i)*dlev)*(tp(k1,i)*en(k1,i)-
-     |    tp(k2,i)*en(k2,i))+mgr*en(k1,i)
-        ans(1,i) = 1./(hj(1,i)*dlev)*(tp(2,i)*en(2,i)-
-     |    tp(1,i)*en(1,i))+mgr*en(1,i)
-      enddo
-      end subroutine diffus
-!-----------------------------------------------------------------------
-      subroutine bdotdh(phijm1,phij,phijp1,ans,lon0,lon1,lev0,lev1,lat)
+      subroutine bdotdh(phij,ans,lev0,lev1,lon0,lon1,lat0,lat1)
       use cons_module,only: re,dphi,dlamda,cs
+      use magfield_module,only: bx,by
 !
 ! Evaluates ans = (b(h)*del(h))*phi
 !
 ! Args:
-      integer :: lon0,lon1,lev0,lev1,lat
-      real,dimension(lev0:lev1,lon0:lon1),intent(in)    :: phijm1,phijp1
-      real,dimension(lev0:lev1,lon0-2:lon1+2),intent(in) :: phij
-      real,dimension(lev0:lev1,lon0:lon1),intent(out)   :: ans
+      integer,intent(in) :: lev0,lev1,lon0,lon1,lat0,lat1
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(in) :: phij
+      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1),intent(out) :: ans
 !
 ! Local:
-      integer :: k,i,lonbeg,lonend
-!
-      lonbeg = lon0
-      if (lon0==1) then
-        lonbeg = 3
-        ans(:,lon0:lon1) = 0. ! set periodic points to zero to avoid NaNS trap
-      endif
-      lonend = lon1
-      if (lon1==nlonp4) then
-        lonend = lon1-2
-        ans(:,lon1-1:lon1) = 0. ! set periodic points to zero to avoid NaNS trap
-      endif
+      integer :: k,i,lat
+      real :: dphidx,dphidy
 !
 ! Note phij longitude dimension is lon0-2:lon1+2 (only i-1 and i+1 are used).
 ! Boundary longitudes i-1 and i+1 must have been set before this routine is
 ! called (e.g., call mp_bndlons_f3d).
 !
-      do i=lonbeg,lonend
-        do k=lev0,lev1-1
-          ans(k,i) = 1./re*(bx(i,lat)/(cs(lat)*2.*dlamda)*
-     |      (phij(k,i+1)-phij(k,i-1))+by(i,lat)*
-     |      (phijp1(k,i)-phijm1(k,i))/(2.*dphi))
-        enddo ! k=lev0,lev1
-      enddo ! i=lonbeg,lonend
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            dphidx = (phij(k,i+1,lat)-phij(k,i-1,lat))/(2.*dlamda)
+            dphidy = (phij(k,i,lat+1)-phij(k,i,lat-1))/(2.*dphi)
+            ans(k,i,lat) = 1./re*
+     |        (bx(i,lat)*dphidx/cs(lat)+by(i,lat)*dphidy)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !
       end subroutine bdotdh
 !-----------------------------------------------------------------------
-      subroutine bdzdvb(phi,dvb,h,ans,lev0,lev1,lon0,lon1,lat)
+      subroutine calc_terms(xnmbar,diffj,Fe,Fn,
+     |  opout,optm1_smooth,op_prod,op_loss,
+     |  diffexp,diffp,diffq,diffr,
+     |  vdotn_h,driftp,driftq,driftr,
+     |  bdotdh_bvel,windp,windq,windr,
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
-! Evaluates  ans = (bz*d/(h*dz)+divb)*phi
+! Post-processing diagnostic term analysis.
+! This is called only at the last sub-cycling step
+!
+      use cons_module,only: dtx2inv
+      use input_module,only: nstep_sub
+      use magfield_module,only: dipmag,sndec,csdec
+      use addfld_module,only: addfld
 !
 ! Args:
-      integer :: lev0,lev1,lon0,lon1,lat
-      real,intent(in) :: dvb(lon0:lon1)
-      real,dimension(lev0:lev1,lon0:lon1),intent(in)    :: phi,h
-      real,dimension(lev0:lev1,lon0:lon1),intent(out)   :: ans
+      integer,intent(in) ::
+     |  lev0,lev1, ! first,last pressure  indices for current task (bot->top)
+     |  lon0,lon1, ! first,last longitude indices for current task (W->E)
+     |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
+!
+! Input fields (full 3d task subdomain):
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(in) ::
+     |  xnmbar,diffj,
+     |  opout,         ! O+ output for next timestep
+     |  optm1_smooth, ! op at time n-1, with shapiro smoother (was s1)
+     |  op_prod,op_loss,
+     |  diffexp,diffp,diffq,diffr,
+     |  vdotn_h,driftp,driftq,driftr,
+     |  bdotdh_bvel,windp,windq,windr
+!
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+     |  intent(out) :: Fe,Fn
 !
 ! Local:
-      integer :: k,i
+      integer :: k,i,lat
+      real :: wd
+      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
+     |  dopdt,op_loss_out,diffsum,driftsum,windsum
 !
-      do i=lon0,lon1
-        do k=lev0+1,lev1-2
-          ans(k,i) = bz(i,lat)/(2.*h(k,i)*dz)*(phi(k+1,i)-phi(k-1,i))+
-     |      dvb(i)*phi(k,i)
-        enddo ! k=lev0+1,lev1-1
-      enddo ! i=lon0,lon1
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            wd = 16*3.53*1.42E6/xnmbar(k,i,lat)*diffj(k,i,lat)*
+     |        sin(dipmag(i,lat))*cos(dipmag(i,lat))
+            Fe(k,i,lat) = wd*sndec(i,lat)
+            Fn(k,i,lat) = wd*csdec(i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+!       call addfld('PARDRAG_U','','',Fe(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('PARDRAG_V','','',Fn(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
-! Upper and lower boundaries:
-      do i=lon0,lon1
-        ans(lev1-1,i) = bz(i,lat)/(h(lev1-1,i)*dz)*(phi(lev1-1,i)-
-     |    phi(lev1-2,i))+dvb(i)*phi(lev1-1,i)
-        ans(lev0,i) = bz(i,lat)/(h(lev0,i)*dz)*
-     |    (phi(lev0+1,i)-phi(lev0,i))+dvb(i)*phi(lev0,i)
-      enddo ! i=lon0,lon1
-      end subroutine bdzdvb
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            dopdt(k,i,lat) = dtx2inv*nstep_sub*
+     |        (opout(k,i,lat)-optm1_smooth(k,i,lat))
+            op_loss_out(k,i,lat) = op_loss(k,i,lat)*opout(k,i,lat)
+          enddo ! k=lev0,lev1-1
+          do k=lev0+1,lev1-1
+            diffsum (k,i,lat) = diffexp(k,i,lat)+
+     |        diffp (k,i,lat)*opout(k-1,i,lat)+
+     |        diffq (k,i,lat)*opout(k  ,i,lat)+
+     |        diffr (k,i,lat)*opout(k+1,i,lat)
+            driftsum(k,i,lat) = -vdotn_h(k,i,lat)+
+     |        driftp(k,i,lat)*opout(k-1,i,lat)+
+     |        driftq(k,i,lat)*opout(k  ,i,lat)+
+     |        driftr(k,i,lat)*opout(k+1,i,lat)
+            windsum (k,i,lat) = -bdotdh_bvel(k,i,lat)+
+     |        windp (k,i,lat)*opout(k-1,i,lat)+
+     |        windq (k,i,lat)*opout(k  ,i,lat)+
+     |        windr (k,i,lat)*opout(k+1,i,lat)
+          enddo ! k=lev0+1,lev1-1
+        enddo ! i=lon0,lon1
+        call addfld('DOPDT','O+ changing rate','cm-3s-1',
+     |    dopdt(lev0:lev1-1,:,lat),
+     |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+        call addfld('OP_PROD','O+ production','cm-3s-1',
+     |    op_prod(lev0:lev1-1,:,lat),
+     |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+        call addfld('OP_LOSS','O+ loss','cm-3s-1',
+     |    -op_loss_out(lev0:lev1-1,:,lat),
+     |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+        call addfld('OP_DIFF',
+     |    'O+ transport due to ambipolar diffusion','cm-3s-1',
+     |    diffsum(lev0+1:lev1-1,:,lat),
+     |    'lev',lev0+1,lev1-1,'lon',lon0,lon1,lat)
+        call addfld('OP_DRIFT',
+     |    'O+ transport due to ion drift','cm-3s-1',
+     |     driftsum(lev0+1:lev1-1,:,lat),
+     |    'lev',lev0+1,lev1-1,'lon',lon0,lon1,lat)
+        call addfld('OP_WIND',
+     |    'O+ transport due to neutral wind','cm-3s-1',
+     |    windsum(lev0+1:lev1-1,:,lat),
+     |    'lev',lev0+1,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+      end subroutine calc_terms
 !-----------------------------------------------------------------------
       subroutine filter_op(opout,lev0,lev1,lon0,lon1,lat0,lat1,name)
 !
 ! Filter updated O+. This is called from outside latitude loop,
 ! i.e., once per timestep.
 !
+      use params_module,only: nlonp4
       use mpi_module,only: mytidi,mp_gatherlons_f3d,mp_scatterlons_f3d
 !
 ! Args:
       integer,intent(in) :: lev0,lev1,lon0,lon1,lat0,lat1
-      real,intent(inout) :: opout(lev0:lev1,lon0:lon1,lat0:lat1)
+      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1),intent(inout) ::
+     |  opout
       character(len=*),intent(in) :: name
 !
 ! Local:
-      integer :: i,j,ier
-      real :: op_ik(nlonp4,lev0:lev1),op_kij(lev0:lev1,nlonp4,lat0:lat1)
+      integer :: k,i,lat,ier
+      real,dimension(nlonp4,lev0:lev1) :: op_ik
+      real,dimension(lev0:lev1,nlonp4,lat0:lat1) :: op_kij
 !
 #ifdef VT
 !     code = 124 ; state = 'filter_op' ; activity='Filtering'
@@ -1281,52 +1473,60 @@
 !
 ! Define lons in op_kij from current task subdomain opout:
       op_kij = 0.
-      do j=lat0,lat1
+      do lat=lat0,lat1
         do i=lon0,lon1
-          op_kij(:,i,j) = opout(:,i,j)
-        enddo
-      enddo ! j=lat0,lat1
+          do k=lev0,lev1
+            op_kij(k,i,lat) = opout(k,i,lat)
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !
 ! Gather longitudes into tasks in first longitude column of task table
-!   (leftmost of each j-row) for global fft. (i.e., tasks with mytidi==0 
+!   (leftmost of each lat-row) for global fft. (i.e., tasks with mytidi==0
 !   gather lons from other tasks in that row). This includes all latitudes.
 !
       call mp_gatherlons_f3d(op_kij,lev0,lev1,lon0,lon1,lat0,lat1,1,
      |  name)
 !
-! Only leftmost tasks at each j-row of tasks does the global filtering:
+! Only leftmost tasks at each lat-row of tasks does the global filtering:
         if (mytidi==0) then
 !
 ! Loop through subdomain latitudes:
-          latscan: do j=lat0,lat1
+          latscan: do lat=lat0,lat1
 !
 ! Define 2d array at all longitudes for filter:
             do i=1,nlonp4
-              op_ik(i,:) = op_kij(:,i,j)
+              do k=lev0,lev1
+                op_ik(i,k) = op_kij(k,i,lat)
+              enddo ! k=lev0,lev1
             enddo ! i=1,nlonp4
 !
 ! Do the filtering:
-            call ringfilter(op_ik,lev0,lev1,3,name,j)
+            call ringfilter(op_ik,lev0,lev1,3,name,lat)
 !
 ! Return filtered array to op_kij:
             do i=1,nlonp4
-              op_kij(:,i,j) = op_ik(i,:)
+              do k=lev0,lev1
+                op_kij(k,i,lat) = op_ik(i,k)
+              enddo ! k=lev0,lev1
             enddo ! i=1,nlonp4
-          enddo latscan ! j=lat0,lat1
+          enddo latscan ! lat=lat0,lat1
         endif ! mytidi==0
 !
-! Now leftmost task at each j-row must redistribute filtered data
-! back to other tasks in the j-row (mytidi>0,mytidj) (includes latitude):
+! Now leftmost task at each lat-row must redistribute filtered data
+! back to other tasks in the lat-row (mytidi>0,mytidj) (includes latitude):
 !
       call mp_scatterlons_f3d(op_kij,lev0,lev1,lon0,lon1,lat0,lat1,1,
      |  name)
 !
 ! Return filtered array to opout at task subdomain:
-      do j=lat0,lat1
+      do lat=lat0,lat1
         do i=lon0,lon1
-          opout(:,i,j) = op_kij(:,i,j)
-        enddo
-      enddo
+          do k=lev0,lev1
+            opout(k,i,lat) = op_kij(k,i,lat)
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !
 #ifdef VT
 !     code = 124 ; state = 'filter_op' ; activity='Filtering'

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -10,6 +10,7 @@
 #ifdef VT
 #include <VT.inc>
 #endif
+!
       implicit none
 !
 ! 2024/09 Haonan Wu: rewrite the whole oplus module
@@ -108,7 +109,6 @@
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
 ! Filter updated O+:
-!
         call filter_op(opout_sub(:,lon0:lon1,lat0:lat1),
      |    lev0,lev1,lon0,lon1,lat0,lat1,'OPLUS')
 !
@@ -235,12 +235,11 @@
      |  phin = -2.0e8,
      |  ppolar = 0.
       integer :: k,i,lat,lonbeg,lonend,nlevs
-      real :: gmr,a,fed,fen,dbxdx,dbydy,tr,djmin,
+      real :: gmr,a,fed,fen,dbxdx,dbydy,tr,djmin,bdotdh_djbz2,
      |  ubca, ubcb ! O+ upper boundary condition (were t2,t3)
       real,dimension(lev0:lev1) :: bdotu1
       real,dimension(lon0:lon1,lat0:lat1) ::
-     |  opflux,    ! upward number flux of O+ (returned by sub oplus_flux) (t7)
-     |  dvb_bz
+     |  opflux     ! upward number flux of O+ (returned by sub oplus_flux) (t7)
       real,dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
      |  hdz,              ! was s15
      |  tphdz1,tphdz0,    ! were s13,s12 (using gmr)
@@ -257,21 +256,6 @@
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
-!
-! Save inputs to secondary history file:
-!
-!     do lat=lat0,lat1
-!       call addfld('TE_OP',' ',' ',te(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('TI_OP',' ',' ',ti(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('N2D_OP',' ',' ',n2d(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('NE_OP',' ',' ',ne(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('WI_OP',' ',' ',wi(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
 !
 ! Calculate O+ number flux in opflux for sub oplus (was sub opflux).
 !
@@ -300,11 +284,11 @@
      |      opflux(i,lat) = opflux(i,lat)+ppolar
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
+!
 !     call addfld('OPFLUX',' ',' ',opflux,
 !    |  'lon',lon0,lon1,'lat',lat0,lat1,0)
 !
 ! Evaluate divergence of B, the unit magnetic field vector.
-!
       lonbeg = lon0
       if (lon0==1) lonbeg = 3
       lonend = lon1
@@ -319,8 +303,10 @@
           dvb(i,lat) = ((dbxdx+dbydy)/cs(lat)+2.*bz(i,lat))/re
         enddo ! i=lonbeg,lonend
       enddo ! lat=lat0,lat1
+!
       call mp_periodic_f2d(dvb(lon0:lon1,lat0:lat1),
      |  lon0,lon1,lat0,lat1,1)
+!
 !     call addfld('OP_DIVB',' ',' ',dvb(lon0:lon1,lat0:lat1),
 !    |  'lon',lon0,lon1,'lat',lat0,lat1,0)
 !
@@ -332,15 +318,15 @@
 !
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             o2_cm3(k,i,lat) = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
             o1_cm3(k,i,lat) = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
             he_cm3(k,i,lat) = xnmbar(k,i,lat)*he(k,i,lat)*rmassinv_he
             n2_cm3(k,i,lat) = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
             n2d_cm3(k,i,lat) = xnmbar(k,i,lat)*n2d(k,i,lat)*rmassinv_n2d
-          enddo
-        enddo
-      enddo
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
 !
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
@@ -355,11 +341,9 @@
 !   change in O+ and Ne, and very small differences in NMF2,HMF2,TEC.
 !   Wenbin feels there should be larger changes in these fields
 !   as a consequence of fixing this bug.
-!
             tr = 0.5*(tn(k,i,lat)+ti(k,i,lat))
 !
 ! 8/28/13 btf: Use n2=1-o2-o-he, and include O+/He collision rate from Wenbin:
-!
             dj(k,i,lat) = 1.42E17/(18.1*o2_cm3(k,i,lat)+
      |        3.6*he_cm3(k,i,lat)+18.6*n2_cm3(k,i,lat)+
      |        o1_cm3(k,i,lat)*sqrt(tr)*(1.-0.064*log10(tr))**2*colfac)
@@ -379,7 +363,6 @@
 !
 ! 2024/08 Haonan Wu: Change the original constant O+ diffusion cap
 !   to an altitude-dependent cap (use logistic function for now)
-!
       if (opdiffcap/=0. .and. opdiffrate/=0. .and.
      |    opdifflev/=spval) then
         do lat=lat0-2,lat1+2
@@ -391,12 +374,25 @@
           enddo ! i=lon0-2,lon1+2
         enddo ! lat=lat0-2,lat1+2
       endif
-
+!
 !     do lat=lat0,lat1
 !       call addfld('DJ','DJ: Ambipolar Diffusion of O+',' ',
 !    |    dj(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !     enddo ! lat=lat0,lat1
+!
+! djint = dj at interfaces:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-2
+            djint(k+1,i,lat) = 0.5*(dj(k,i,lat)+dj(k+1,i,lat))
+          enddo ! k=lev0,lev1-2
+          djint(lev0,i,lat) = 1.5*dj(lev0  ,i,lat)-0.5*dj(lev0+1,i,lat)
+          djint(lev1,i,lat) = 1.5*dj(lev1-1,i,lat)-0.5*dj(lev1-2,i,lat)
+        enddo ! i=lon0,lon1
+!       call addfld('DJINT',' ',' ',djint(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
 !
 ! Plasma temperature:
       do lat=lat0-2,lat1+2
@@ -408,6 +404,17 @@
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
 !
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            tp1(k+1,i,lat) = tp(k,i,lat)
+          enddo ! k=lev0,lev1-1
+          tp1(lev0,i,lat) = 2.*tp(lev0,i,lat)-tp(lev0+1,i,lat)
+        enddo ! i=lon0,lon1
+!       call addfld('TP1',' ',' ',tp1(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
 ! bdotu = B.U (s7)
       do lat=lat0,lat1
         do i=lon0,lon1
@@ -417,7 +424,7 @@
      |        scht(k,i,lat)*bz(i,lat)*0.5*(w(k,i,lat)+w(k+1,i,lat))
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-!       call addfld('BDOTU' ,' ',' ',bdotu(lev0:lev1-1,lon0:lon1,lat),
+!       call addfld('BDOTU',' ',' ',bdotu(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
@@ -453,25 +460,12 @@
 !
       do lat=lat0,lat1
         do i=lon0,lon1
-          dvb_bz(i,lat) = dvb(i,lat)/bz(i,lat)
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
-!
-      do lat=lat0,lat1
-        do i=lon0,lon1
           do k=lev0,lev1
             hdz(k,i,lat) = 1./(scht(k,i,lat)*dz)
           enddo ! k=lev0,lev1
-          do k=lev0,lev1-1
-            tp1(k+1,i,lat) = tp(k,i,lat)
-          enddo ! k=lev0,lev1-1
-          tp1(lev0,i,lat) = 2.*tp(lev0,i,lat)-tp(lev0+1,i,lat)
         enddo ! i=lon0,lon1
-
-!       call addfld('TP1',' ',' ',tp1(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('HDZ',' ',' ',hdz(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('HDZ',' ',' ',hdz(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
       do lat=lat0,lat1
@@ -495,23 +489,9 @@
             tphdz0(k,i,lat) = 2.*tp1(k,i,lat)*hdzi(k,i,lat)-gmr ! s12
           enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
-
 !       call addfld('TPHDZ1',' ',' ',tphdz1(:,:,lat),
 !    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
 !       call addfld('TPHDZ0',' ',' ',tphdz0(:,:,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-! djint = dj at interfaces:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-2
-            djint(k+1,i,lat) = 0.5*(dj(k,i,lat)+dj(k+1,i,lat))
-          enddo ! k=lev0,lev1-2
-          djint(lev0,i,lat) = 1.5*dj(lev0  ,i,lat)-0.5*dj(lev0+1,i,lat)
-          djint(lev1,i,lat) = 1.5*dj(lev1-1,i,lat)-0.5*dj(lev1-2,i,lat)
-        enddo ! i=lon0,lon1
-!       call addfld('DJINT' ,' ',' ',djint(:,:,lat),
 !    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
@@ -521,17 +501,16 @@
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
-            divbz(k,i,lat) = dvb_bz(i,lat)+
-     |        bdotdh_djbz(k,i,lat)/(djbz(k,i,lat)*bz(i,lat))
+            bdotdh_djbz2 = bdotdh_djbz(k,i,lat)/djbz(k,i,lat)
+            divbz(k,i,lat) = (dvb(i,lat)+bdotdh_djbz2)/bz(i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-!       call addfld('DIVBZ' ,' ',' ',divbz(lev0:lev1-1,:,lat),
+!       call addfld('DIVBZ',' ',' ',divbz(lev0:lev1-1,:,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
 ! hdzmbz = (1./(H*DZ)-(DIV(B)+DH*D*BZ/(D*BZ))/(2*BZ))*BZ**2 (was s10)
 ! hdzpbz = (1./(H*DZ)+(DIV(B)+DH*D*BZ/(D*BZ))/(2*BZ))*BZ**2 (was s9 )
-!
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
@@ -541,7 +520,6 @@
      |        (hdz(k,i,lat)+0.5*divbz(k,i,lat))*bz(i,lat)**2
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
 !       call addfld('HDZMBZ' ,' ',' ',hdzmbz(lev0:lev1-1,:,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !       call addfld('HDZPBZ' ,' ',' ',hdzpbz(lev0:lev1-1,:,lat),
@@ -571,7 +549,6 @@
             diffr(k,i,lat) =   hdzpbz(k,i,lat)*djint_tphdz1_1(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
 !       call addfld('P_COEFF0',' ',' ',
 !    |    diffp(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
@@ -594,7 +571,6 @@
      |        -0.5*(wi(k,i,lat)+wi(k+1,i,lat))*0.5*hdz(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
 !       call addfld('P_COEFF1',' ',' ',
 !    |    driftp(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
@@ -629,7 +605,6 @@
             windr(k,i,lat) = -bz(i,lat)*bdotu1(k)*0.5*hdz(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
 !       call addfld('P_COEFF2',' ',' ',
 !    |    windp(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
@@ -641,60 +616,7 @@
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
-! Additions to Q coefficients:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            p_coeff(k,i,lat) =
-     |        diffp(k,i,lat)+driftp(k,i,lat)+windp(k,i,lat)
-            q_coeff(k,i,lat) =
-     |        diffq(k,i,lat)+driftq(k,i,lat)+windq(k,i,lat)-
-     |        dtx2inv*nstep_sub
-            r_coeff(k,i,lat) =
-     |        diffr(k,i,lat)+driftr(k,i,lat)+windr(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
-!
-! Upper boundary condition for O+:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          ubcb = -bz(i,lat)**2*djint_tphdz0(lev1,i,lat) ! t3
-          ubca = -bz(i,lat)**2*djint_tphdz1(lev1,i,lat) ! t2
-!
-! Q = Q+B/A*R
-          q_coeff(lev1-1,i,lat) = q_coeff(lev1-1,i,lat)+
-     |      ubcb/ubca*r_coeff(lev1-1,i,lat)
-!
-! F = F -R/A*PHI
-          ubcrhs(i,lat) = opflux(i,lat)*r_coeff(lev1-1,i,lat)/ubca
-          r_coeff(lev1-1,i,lat) = 0.
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
-
-!     do lat=lat0,lat1
-!       call addfld('P_COEFF3',' ',' ',
-!    |    p_coeff(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('Q_COEFF3',' ',' ',
-!    |    q_coeff(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('R_COEFF3',' ',' ',
-!    |    r_coeff(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-
-!       call addfld('QOP2P_OP',' ',' ',qop2p(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('QOP2D_OP',' ',' ',qop2d(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('RK20',' ',' ',rk20(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('RK25',' ',' ',rk25(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
-!
 ! Sources and sinks (xiop2p and xiop2d are outputs):
-!
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
@@ -713,35 +635,6 @@
             op_loss(k,i,lat) = rk1(k,i,lat)*o2_cm3(k,i,lat)+
      |        rk2(k,i,lat)*n2_cm3(k,i,lat)+rk10*n2d_cm3(k,i,lat)
 !
-            q_coeff(k,i,lat) = q_coeff(k,i,lat)-op_loss(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-
-!       call addfld('XIOP2P',' ',' ',xiop2p(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('XIOP2D',' ',' ',xiop2d(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OP_LOSS_COEF',' ',' ',
-!    |    op_loss(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('OP_QOP',' ',' ',qop(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OP_NE' ,' ',' ',ne(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OP_O1' ,' ',' ',o1(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OP_TN' ,' ',' ',tn(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OP_RK19' ,' ',' ',rk19(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('OP_RK25' ,' ',' ',rk25(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-! Add source term to RHS (explicit terms):
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
             op_prod(k,i,lat) =
      |        0.5*(qop(k,i,lat)+qop(k+1,i,lat))+
      |        (rk19(k,i,lat)*ne(k,i,lat)+rk21)*xiop2p(k,i,lat)+
@@ -749,6 +642,47 @@
      |        (rk18*xiop2p(k,i,lat)+rk24*xiop2d(k,i,lat))*
      |        o1_cm3(k,i,lat)
           enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+!       call addfld('XIOP2P',' ',' ',xiop2p(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('XIOP2D',' ',' ',xiop2d(lev0:lev1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_LOSS_COEF',' ',' ',
+!    |    op_loss(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OP_PROD',' ',' ',
+!    |    op_prod(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Additions to Q coefficients, Sinks:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            p_coeff(k,i,lat) =
+     |        diffp(k,i,lat)+driftp(k,i,lat)+windp(k,i,lat)
+            q_coeff(k,i,lat) =
+     |        diffq(k,i,lat)+driftq(k,i,lat)+windq(k,i,lat)-
+     |        dtx2inv*nstep_sub-op_loss(k,i,lat)
+            r_coeff(k,i,lat) =
+     |        diffr(k,i,lat)+driftr(k,i,lat)+windr(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+!
+! Upper boundary condition for O+:
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          ubcb = -bz(i,lat)**2*djint_tphdz0(lev1,i,lat) ! t3
+          ubca = -bz(i,lat)**2*djint_tphdz1(lev1,i,lat) ! t2
+!
+! Q = Q+B/A*R
+          q_coeff(lev1-1,i,lat) = q_coeff(lev1-1,i,lat)+
+     |      ubcb/ubca*r_coeff(lev1-1,i,lat)
+!
+! F = F-R/A*PHI
+          ubcrhs(i,lat) = opflux(i,lat)*r_coeff(lev1-1,i,lat)/ubca
+          r_coeff(lev1-1,i,lat) = 0.
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
 !
@@ -761,7 +695,7 @@
           p_coeff(lev0,i,lat) = 0.
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
-
+!
 !     do lat=lat0,lat1
 !       call addfld('P_COEFF',' ',' ',
 !    |    p_coeff(lev0:lev1-1,lon0:lon1,lat),
@@ -770,10 +704,10 @@
 !    |    q_coeff(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !       call addfld('R_COEFF',' ',' ',
-!    |    r_coeff(lev0:lev1-2,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-2,'lon',lon0,lon1,lat)
+!    |    r_coeff(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !     enddo ! lat=lat0,lat1
-
+!
       end subroutine prep_oplus
 !-----------------------------------------------------------------------
       subroutine smooth_oplus(optm1,optm1_smooth,
@@ -920,31 +854,6 @@
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
 !
-! Save inputs to secondary history file:
-!
-!     do lat=lat0,lat1
-!       call addfld('OP_OPLUS',' ',' ',op(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('UI_OP',' ',' ',ui(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('VI_OP',' ',' ',vi(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
-!
-! bvel @ j   = (B.U)*N(O+)      (J) (was s7)
-!
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
-            bvel(k,i,lat) = bdotu(k,i,lat)*op(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
-!     do lat=lat0,lat1
-!       call addfld('BVEL_J',' ',' ',bvel(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
-!
 ! Plasma temperature times O+
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
@@ -953,6 +862,7 @@
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
+!
 !     do lat=lat0,lat1
 !       call addfld('TPJ','TP after times OP',' ',
 !    |    tpop(lev0:lev1-1,lon0:lon1,lat),
@@ -960,7 +870,6 @@
 !     enddo ! lat=lat0,lat1
 !
 ! Evaluates ans = (d/(h*dz)*tp+m*g/r)*en
-!
       mgr = rmass_op*grav/gask
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
@@ -978,7 +887,7 @@
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
-
+!
 !     do lat=lat0,lat1
 !       call addfld('DIFFJ','DIFFJ after diffus',' ',
 !    |    diffj(lev0:lev1-1,lon0:lon1,lat),
@@ -997,14 +906,12 @@
      |        dj(k,i,lat)*bz(i,lat)*bdotdh_op(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
 !       call addfld('BDOTDH_1',' ',' ',
 !    |    bdotdh_op(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
 ! bdotdh_opj   = (B(H).DEL(H))*2.*TP*N(O+)      (J)
-!
       call bdotdh(2.*tpop,bdotdh_opj(:,lon0:lon1,lat0:lat1),
      |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
@@ -1014,7 +921,6 @@
             bdotdh_opj(k,i,lat) = bdotdh_opj(k,i,lat)*dj(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
 !       call addfld('BDOTDH_2',' ',' ',
 !    |    bdotdh_opj(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
@@ -1050,16 +956,11 @@
       enddo ! lat=lat0-2,lat1+2
 !
 ! bdotdh_opj = (B(H).DEL(H))*D*(B(H).DEL(H))*2.*TP*N(O+)   (J)
-! Note bdotdh_opj longitude dimension is lon-2:lon+2. bdotdh_diff
-!   is returned. (periodic points apparently not necessary for
-!   bdotdh_diff)
-!
+! Note bdotdh_opj longitude dimension is lon-2:lon+2. bdotdh_diff is returned.
+! (periodic points apparently not necessary for bdotdh_diff)
       call bdotdh(bdotdh_opj,bdotdh_diff,lev0,lev1,lon0,lon1,lat0,lat1)
-
+!
 !     do lat=lat0,lat1
-!       call addfld('BDOT_J'  ,' ',' ',
-!    |    bdotdh_opj(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !       call addfld('BDOT_DIF',' ',' ',
 !    |    bdotdh_diff(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
@@ -1068,7 +969,6 @@
 ! bdzdvb_op = (BZ*D/(H*DZ)+DIV(*B))*S2
 !
 ! Evaluates (bz*d/(h*dz)+divb)*phi
-!
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0+1,lev1-2
@@ -1088,30 +988,31 @@
      |        dvb(i,lat)*bdotdh_opj(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
 !       call addfld('BDZDVB',' ',' ',bdzdvb_op(lev0:lev1-1,:,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
-! Collect explicit terms:
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
             diffexp(k,i,lat) =
      |        bdzdvb_op(k,i,lat)+bdotdh_diff(k,i,lat)+bdotdh_op(k,i,lat)
-            explicit(k,i,lat) = -diffexp(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
-!       call addfld('EXPLIC0',' ',' ',explicit(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
-
+!
+! bvel @ j   = (B.U)*N(O+)      (J) (was s7)
+      do lat=lat0-2,lat1+2
+        do i=lon0-2,lon1+2
+          do k=lev0,lev1-1
+            bvel(k,i,lat) = bdotu(k,i,lat)*op(k,i,lat)
+          enddo ! k=lev0,lev1-1
+        enddo ! i=lon0-2,lon1+2
+      enddo ! lat=lat0-2,lat1+2
+!
 !     do lat=lat0,lat1
-!       call addfld('UI_VEL',' ',' ',ui(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('VI_VEL',' ',' ',vi(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('BVEL_J',' ',' ',bvel(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !     enddo ! lat=lat0,lat1
 !
       call bdotdh(bvel,bdotdh_bvel(:,lon0:lon1,lat0:lat1),
@@ -1129,54 +1030,29 @@
      |        1./dphi*
      |        0.5*(vi(k,i,lat)+vi(k+1,i,lat))*
      |        (op_bmod2(k,i,lat+1)-op_bmod2(k,i,lat-1)))
-!
-            explicit(k,i,lat) = explicit(k,i,lat)+
-     |        vdotn_h(k,i,lat)+bdotdh_bvel(k,i,lat)
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
-
-!       call addfld('EXPLIC1',' ',' ',explicit(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
+! Collect explicit terms:
 ! Sum O+ at time n-1 to explicit terms: N(O+)/(2*DT) (N-1) (was s4)
-!
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            explicit(k,i,lat) = explicit(k,i,lat)-
-     |        optm1_smooth(k,i,lat)*dtx2inv*nstep_sub
-          enddo ! k=lev0,lev1
-        enddo ! i=lon0,lon1
-
-!       call addfld('OPTM1_SM1' ,' ',' ',
-!    |    optm1_smooth(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('EXPLIC2' ,' ',' ',explicit(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-! Upper boundary condition for O+:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-!
-! F = F -R/A*PHI
-          explicit(lev1-1,i,lat) = explicit(lev1-1,i,lat)-ubcrhs(i,lat)
-        enddo ! i=lon0,lon1
-
-!       call addfld('EXPLIC3',' ',' ',explicit(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
 ! Add source term to RHS (explicit terms):
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
-            explicit(k,i,lat) = explicit(k,i,lat)-op_prod(k,i,lat)
-          enddo ! k=lev0,lev1-1
+            explicit(k,i,lat) = -diffexp(k,i,lat)+
+     |        vdotn_h(k,i,lat)+bdotdh_bvel(k,i,lat)-
+     |        optm1_smooth(k,i,lat)*dtx2inv*nstep_sub-
+     |        op_prod(k,i,lat)
+          enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
-!       call addfld('EXPLIC4',' ',' ',explicit(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+      enddo ! lat=lat0,lat1
+!
+! Upper boundary condition for O+ (F = F-R/A*PHI):
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          explicit(lev1-1,i,lat) = explicit(lev1-1,i,lat)-ubcrhs(i,lat)
+        enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
 !
 ! Lower boundary condition N(O+) = Q/L:
@@ -1184,15 +1060,14 @@
         do i=lon0,lon1
           explicit(lev0,i,lat) = explicit(lev0,i,lat)-lbcrhs(i,lat)
         enddo ! i=lon0,lon1
-
-!       call addfld('EXPLIC5',' ',' ',explicit(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
-! Tridiagonal solver returns updated O+ in opout (all other args are input):
-!     subroutine trsolv(a,b,c,f,x,lev0,lev1,k1,k2,lon0,lon1,lonmax,lat,
-!    |  idebug)
+!     do lat=lat0,lat1
+!       call addfld('EXPLIC',' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
 !
+! Tridiagonal solver returns updated O+ in opout (all other args are input):
       do lat=lat0,lat1
         call trsolv(
      |    p_coeff(:,lon0:lon1,lat),
@@ -1201,10 +1076,8 @@
      |    explicit(:,lon0:lon1,lat),
      |    opout(:,lon0:lon1,lat),
      |    lev0,lev1,lev0,lev1-1,lon0,lon1,nlonp4,lat,0)
-!
 !       call addfld('OP_SOLV',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-
       enddo ! lat=lat0,lat1
 !
 ! Periodic points for outputs:
@@ -1215,6 +1088,7 @@
 !     code = 113 ; state = 'oplus' ; activity='ModelCode'
       call vtend(113,ier)
 #endif
+!
       end subroutine iterate_oplus
 !-----------------------------------------------------------------------
       subroutine post_oplus(op,optm1,opout,optm1out,
@@ -1262,7 +1136,6 @@
 !  e.g., it allows the 2.5-deg June solstice solar max
 !  benchmark to run with step=30 rather than step=20, and
 !  may improve stability in other cases as well.)
-!
       real :: opmin
 !
 ! Time smoothing:
@@ -1271,7 +1144,6 @@
 ! op(k,i,lat)      : O+ at current latitude and time.
 ! optm1(k,i,lat)   : O+ at current latitude and time n-1.
 ! opout(k,i,lat)   : New O+ at current latitude and time.
-!
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
@@ -1289,7 +1161,7 @@
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
 !
-! Insure global non-negative O+:
+! Ensure global non-negative O+:
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
@@ -1307,7 +1179,6 @@
 !   Change the altitude distribution of O+ minimum from Gaussian to logistic,
 !   also change the latitude distribution based on magnetic latitudes
 !   instead of geographic latitudes
-!
       if (opfloor/=0. .and. oprate/=0. .and.
      |    oplev/=spval .and. oplatwidth/=0.) then
         do lat=lat0,lat1
@@ -1331,6 +1202,7 @@
 !    |    optm1out(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !     enddo ! lat=lat0,lat1
+!
       end subroutine post_oplus
 !-----------------------------------------------------------------------
       subroutine bdotdh(phij,ans,lev0,lev1,lon0,lon1,lat0,lat1)
@@ -1352,7 +1224,6 @@
 ! Note phij longitude dimension is lon0-2:lon1+2 (only i-1 and i+1 are used).
 ! Boundary longitudes i-1 and i+1 must have been set before this routine is
 ! called (e.g., call mp_bndlons_f3d).
-!
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1-1
@@ -1448,7 +1319,7 @@
      |    dopdt(lev0:lev1-1,:,lat),
      |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
         call addfld('OP_PROD','O+ production','cm-3s-1',
-     |    op_prod(lev0:lev1-1,:,lat),
+     |    op_prod(lev0:lev1-1,lon0:lon1,lat),
      |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
         call addfld('OP_LOSS','O+ loss','cm-3s-1',
      |    -op_loss_out(lev0:lev1-1,:,lat),
@@ -1554,6 +1425,7 @@
 !     code = 124 ; state = 'filter_op' ; activity='Filtering'
       call vtend(124,ier)
 #endif
+!
       end subroutine filter_op
 !-----------------------------------------------------------------------
       end module oplus_module

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -27,10 +27,7 @@
 ! Outputs are opout, optm1out, xiop2p, xiop2d, Fe, and Fn,
 ! all other args are input.
 !
-      use params_module,only: zpmid,spval  ! for O+ minimum
-      use cons_module,only: rtd
-      use input_module,only: nstep_sub,opfloor,oprate,oplev,oplatwidth
-      use magfield_module,only: rlatm
+      use input_module,only: nstep_sub
       use mpi_module,only: mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
       use addfld_module,only: addfld
 !
@@ -71,18 +68,7 @@
      |  p_coeff,q_coeff,r_coeff,optm1_smooth,
      |  op_sub,optm1_sub,opout_sub,optm1out_sub,
      |  diffj,diffexp,vdotn_h,bdotdh_bvel
-!
-! For O+ "smooth floor". The floor is a
-! spatial gaussian based on the O+ minimum (opmin below).
-!
-! 1/21/16 btf: O+ minimum increased from 1000 to 3000.
-! (This alleviates numerical instability that can develop
-!  near the equator at the top of the model in some cases,
-!  e.g., it allows the 2.5-deg June solstice solar max
-!  benchmark to run with step=30 rather than step=20, and
-!  may improve stability in other cases as well.)
-!
-      real :: opmin
+      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) :: tmpf3d
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
@@ -113,14 +99,13 @@
      |    op_sub,opout_sub,diffj,diffexp,vdotn_h,bdotdh_bvel,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
-        if (istep == nstep_sub) then
-          call calc_terms(xnmbar,diffj,Fe,Fn,
-     |      opout_sub,optm1_smooth,op_prod,op_loss,
-     |      diffexp,diffp,diffq,diffr,
-     |      vdotn_h,driftp,driftq,driftr,
-     |      bdotdh_bvel,windp,windq,windr,
-     |      lev0,lev1,lon0,lon1,lat0,lat1)
-        endif
+        if (istep == nstep_sub)
+     |    call calc_terms(xnmbar,diffj,Fe,Fn,
+     |    opout_sub,optm1_smooth,op_prod,op_loss,
+     |    diffexp,diffp,diffq,diffr,
+     |    vdotn_h,driftp,driftq,driftr,
+     |    bdotdh_bvel,windp,windq,windr,
+     |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
 ! Filter updated O+:
 !
@@ -133,37 +118,29 @@
 !    |      'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !       enddo ! lat=lat0,lat1
 !
-! 12/4/14 btf: Enforce O+ minimum.
-! Opfloor is Stan's "smooth floor" (product of two Gaussians,
-!   dependent on latitude and pressure level) (opmin=1000.0):
-!
-! 2024/08 Haonan Wu:
-!   Change the altitude distribution of O+ minimum from Gaussian to logistic,
-!   also change the latitude distribution based on magnetic latitudes
-!   instead of geographic latitudes
-!
-        if (opfloor/=0. .and. oprate/=0. .and.
-     |      oplev/=spval .and. oplatwidth/=0.) then
-          do lat=lat0,lat1
-            do i=lon0,lon1
-              do k=lev0,lev1-1
-                opmin = opfloor*exp(-(rlatm(i,lat)*rtd/oplatwidth)**2)/
-     |            (1+exp(-oprate*(zpmid(k)-oplev)))
-                if (opout_sub(k,i,lat) < opmin) then
-                  opout_sub(k,i,lat) = opmin
-                endif ! opout_sub < opmin
-              enddo ! k=lev0,lev1-1
-            enddo ! i=lon0,lon1
-          enddo ! lat=lat0,lat1
-        endif
-!
-        call mp_polelats_f3d(opout_sub(:,lon0:lon1,:),
-     |    lev0,lev1,lon0,lon1,lat0,lat1,1,(/1./))
-        call mp_bndlats_f3d(opout_sub,nlevs,lon0,lon1,lat0,lat1,1)
-        call mp_bndlons_f3d(opout_sub,nlevs,lon0,lon1,lat0,lat1,1,0)
-!
         call post_oplus(op_sub,optm1_sub,opout_sub,optm1out_sub,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
+!
+        do lat=lat0,lat1
+          do i=lon0,lon1
+            do k=lev0,lev1
+              tmpf3d(k,i,lat,1) = opout_sub(k,i,lat)
+              tmpf3d(k,i,lat,2) = optm1out_sub(k,i,lat)
+            enddo ! k=lev0,lev1
+          enddo ! i=lon0,lon1
+        enddo ! lat=lat0,lat1
+        call mp_polelats_f3d(tmpf3d(:,lon0:lon1,:,:),
+     |    lev0,lev1,lon0,lon1,lat0,lat1,2,(/1.,1./))
+        call mp_bndlats_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2)
+        call mp_bndlons_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2,0)
+        do lat=lat0-2,lat1+2
+          do i=lon0-2,lon1+2
+            do k=lev0,lev1
+              opout_sub(k,i,lat) = tmpf3d(k,i,lat,1)
+              optm1out_sub(k,i,lat) = tmpf3d(k,i,lat,2)
+            enddo ! k=lev0,lev1
+          enddo ! i=lon0-2,lon1+2
+        enddo ! lat=lat0-2,lat1+2
 !
         do lat=lat0-2,lat1+2
           do i=lon0-2,lon1+2
@@ -403,8 +380,8 @@
 ! 2024/08 Haonan Wu: Change the original constant O+ diffusion cap
 !   to an altitude-dependent cap (use logistic function for now)
 !
-      if (opdiffcap/=0. .and. opdiffrate/=0. .and. opdifflev/=spval)
-     |  then
+      if (opdiffcap/=0. .and. opdiffrate/=0. .and.
+     |    opdifflev/=spval) then
         do lat=lat0-2,lat1+2
           do i=lon0-2,lon1+2
             do k=lev0,lev1-1
@@ -437,7 +414,7 @@
           do k=lev0,lev1-1
             bdotu(k,i,lat) =
      |        bx(i,lat)*un(k,i,lat)+by(i,lat)*vn(k,i,lat)+
-     |        bz(i,lat)*scht(k,i,lat)*0.5*(w(k,i,lat)+w(k+1,i,lat))
+     |        scht(k,i,lat)*bz(i,lat)*0.5*(w(k,i,lat)+w(k+1,i,lat))
           enddo ! k=lev0,lev1-1
         enddo ! i=lon0,lon1
 !       call addfld('BDOTU' ,' ',' ',bdotu(lev0:lev1-1,lon0:lon1,lat),
@@ -1172,9 +1149,9 @@
           enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
 
-!     call addfld('OPTM1_SM1' ,' ',' ',
-!    |  optm1_smooth(lev0:lev1-1,lon0:lon1,lat),
-!    |  'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OPTM1_SM1' ,' ',' ',
+!    |    optm1_smooth(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
 !       call addfld('EXPLIC2' ,' ',' ',explicit(lev0:lev1-1,:,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
@@ -1246,7 +1223,10 @@
 ! Post-processing time smoothing.
 ! This is called after filter_op
 !
-      use cons_module,only: dtsmooth,dtsmooth_div2
+      use params_module,only: zpmid,spval  ! for O+ minimum
+      use cons_module,only: rtd,dtsmooth,dtsmooth_div2
+      use input_module,only: opfloor,oprate,oplev,oplatwidth
+      use magfield_module,only: rlatm
 !
 ! Args:
       integer,intent(in) ::
@@ -1273,6 +1253,18 @@
 ! Local:
       integer :: k,i,lat
 !
+! For O+ "smooth floor". The floor is a
+! spatial gaussian based on the O+ minimum (opmin below).
+!
+! 1/21/16 btf: O+ minimum increased from 1000 to 3000.
+! (This alleviates numerical instability that can develop
+!  near the equator at the top of the model in some cases,
+!  e.g., it allows the 2.5-deg June solstice solar max
+!  benchmark to run with step=30 rather than step=20, and
+!  may improve stability in other cases as well.)
+!
+      real :: opmin
+!
 ! Time smoothing:
 !
 ! optm1out(k,i,lat): New O+ at current latitude and time n-1.
@@ -1280,32 +1272,56 @@
 ! optm1(k,i,lat)   : O+ at current latitude and time n-1.
 ! opout(k,i,lat)   : New O+ at current latitude and time.
 !
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
+      do lat=lat0,lat1
+        do i=lon0,lon1
           do k=lev0,lev1-1
             optm1out(k,i,lat) = dtsmooth*op(k,i,lat)+
      |        dtsmooth_div2*(optm1(k,i,lat)+opout(k,i,lat))
           enddo ! k=lev0,lev1-1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !
 ! Upper boundary:
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
+      do lat=lat0,lat1
+        do i=lon0,lon1
           opout(lev1,i,lat) = 0.
           optm1out(lev1,i,lat) = 0.
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
 !
 ! Insure global non-negative O+:
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
+      do lat=lat0,lat1
+        do i=lon0,lon1
           do k=lev0,lev1-1
             if (opout(k,i,lat)    < 0.) opout(k,i,lat)    = 0.
             if (optm1out(k,i,lat) < 0.) optm1out(k,i,lat) = 0.
           enddo ! k=lev0,lev1-1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+!
+! 12/4/14 btf: Enforce O+ minimum.
+! Opfloor is Stan's "smooth floor" (product of two Gaussians,
+!   dependent on latitude and pressure level):
+!
+! 2024/08 Haonan Wu:
+!   Change the altitude distribution of O+ minimum from Gaussian to logistic,
+!   also change the latitude distribution based on magnetic latitudes
+!   instead of geographic latitudes
+!
+      if (opfloor/=0. .and. oprate/=0. .and.
+     |    oplev/=spval .and. oplatwidth/=0.) then
+        do lat=lat0,lat1
+          do i=lon0,lon1
+            do k=lev0,lev1-1
+              opmin = opfloor*exp(-(rlatm(i,lat)*rtd/oplatwidth)**2)/
+     |          (1+exp(-oprate*(zpmid(k)-oplev)))
+              if (opout(k,i,lat) < opmin) then
+                opout(k,i,lat) = opmin
+              endif ! opout < opmin
+            enddo ! k=lev0,lev1-1
+          enddo ! i=lon0,lon1
+        enddo ! lat=lat0,lat1
+      endif
 !
 ! Save outputs on secondary history for diagnostics:
 !     do lat=lat0,lat1

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -28,6 +28,7 @@
 ! Outputs are opout, optm1out, xiop2p, xiop2d, Fe, and Fn,
 ! all other args are input.
 !
+      use params_module,only: rp
       use input_module,only: nstep_sub
       use mpi_module,only: mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
       use addfld_module,only: addfld
@@ -62,21 +63,23 @@
 !
 ! Local:
       integer :: k,i,lat,nlevs,istep
-      real,dimension(lon0-2:lon1+2,lat0-2:lat1+2) :: dvb,ubcrhs,lbcrhs
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
-     |  dj,tp,bdotu,op_prod,op_loss,diffp,diffq,diffr,
+      real(rp),dimension(lon0-2:lon1+2,lat0-2:lat1+2) ::
+     |  dvb,ubcrhs,lbcrhs
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
+     |  tp,dj,bdotu,op_prod,op_loss,diffp,diffq,diffr,
      |  driftp,driftq,driftr,windp,windq,windr,
      |  p_coeff,q_coeff,r_coeff,optm1_smooth,
      |  op_sub,optm1_sub,opout_sub,optm1out_sub,
      |  diffj,diffexp,vdotn_h,bdotdh_bvel
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) :: tmpf3d
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) ::
+     |  tmpf3d
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
 !
       call prep_oplus(tn,te,ti,
      |  o2,o1,he,n2,n2d,ne,un,vn,w,wi,xnmbar,scht,
-     |  dvb,ubcrhs,lbcrhs,dj,tp,bdotu,xiop2p,xiop2d,
+     |  dvb,ubcrhs,lbcrhs,tp,dj,bdotu,xiop2p,xiop2d,
      |  op_prod,op_loss,diffp,diffq,diffr,
      |  driftp,driftq,driftr,windp,windq,windr,
      |  p_coeff,q_coeff,r_coeff,
@@ -95,7 +98,7 @@
         call smooth_oplus(optm1_sub,optm1_smooth,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
-        call iterate_oplus(dvb,ubcrhs,lbcrhs,dj,tp,bdotu,
+        call iterate_oplus(dvb,ubcrhs,lbcrhs,tp,dj,bdotu,
      |    optm1_smooth,op_prod,ui,vi,scht,p_coeff,q_coeff,r_coeff,
      |    op_sub,opout_sub,diffj,diffexp,vdotn_h,bdotdh_bvel,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
@@ -113,9 +116,8 @@
      |    lev0,lev1,lon0,lon1,lat0,lat1,'OPLUS')
 !
 !       do lat=lat0,lat1
-!         call addfld('OP_FILT',' ',' ',
-!    |      opout_sub(lev0:lev1-1,lon0:lon1,lat),
-!    |      'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!         call addfld('OP_FILT',' ',' ',opout_sub(:,lon0:lon1,lat),
+!    |      'lev',lev0,lev1,'lon',lon0,lon1,lat)
 !       enddo ! lat=lat0,lat1
 !
         call post_oplus(op_sub,optm1_sub,opout_sub,optm1out_sub,
@@ -165,17 +167,17 @@
 !-----------------------------------------------------------------------
       subroutine prep_oplus(tn,te,ti,
      |  o2,o1,he,n2,n2d,ne,un,vn,w,wi,xnmbar,scht,
-     |  dvb,ubcrhs,lbcrhs,dj,tp,bdotu,xiop2p,xiop2d,
+     |  dvb,ubcrhs,lbcrhs,tp,dj,bdotu,xiop2p,xiop2d,
      |  op_prod,op_loss,diffp,diffq,diffr,
      |  driftp,driftq,driftr,windp,windq,windr,
      |  p_coeff,q_coeff,r_coeff,
      |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
-! Calculate terms that are not changing across O+ sub-cycling
+! Calculate terms that do not change with O+ sub-cycling
 !
-      use params_module,only: nlonp4,dz,zpmid,spval
+      use params_module,only: nlonp4,dz,zpmid,spval,rp
       use cons_module,only: rmass_op,gask,grav,re,cs,dphi,dlamda,
-     |  dtx2inv,pi,dtr,rmassinv_o2,rmassinv_o1,
+     |  boltz,dtx2inv,pi,dtr,rmassinv_o2,rmassinv_o1,
      |  rmassinv_he,rmassinv_n2,rmassinv_n2d
       use input_module,only: nstep_sub,colfac,
      |  opdiffcap,opdiffrate,opdifflev
@@ -201,7 +203,7 @@
      |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
 !
 ! Input fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(in) ::
      |  tn, te, ti, ! neutral, electron, and ion temperatures (deg K)
      |  o2, o1, he, ! O2, O, He mass mixing ratios
@@ -214,45 +216,56 @@
      |  scht        ! scale height
 !
 ! Output fields (full 2d task subdomain):
-      real,dimension(lon0-2:lon1+2,lat0-2:lat1+2),intent(out) ::
+      real(rp),dimension(lon0-2:lon1+2,lat0-2:lat1+2),intent(out) ::
      |  dvb,        ! output of sub divb
      |  ubcrhs,lbcrhs
 !
 ! Output fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(out) ::
-     |  dj,          ! diffusion coefficients (s13,s14,s15)
      |  tp,          ! Plasma temperature 0.5*(te+ti)
+     |  dj,          ! diffusion coefficients (s13,s14,s15)
      |  bdotu,       ! was s7 (B.U)
+     |  op_prod,     ! production rate
+     |  op_loss,     ! was s13
      |  xiop2p,xiop2d,
-     |  op_prod,op_loss,diffp,diffq,diffr,
-     |  driftp,driftq,driftr,windp,windq,windr,
+     |  diffp,diffq,diffr,      ! tridiagonal coefficients related to diffusion
+     |  driftp,driftq,driftr,   ! tridiagonal coefficients related to ion drift
+     |  windp,windq,windr,      ! tridiagonal coefficients related to wind
      |  p_coeff,q_coeff,r_coeff ! coefficients for tridiagonal solver (s1,s2,s3)
 !
 ! Local:
-      real,parameter ::
+      real(rp),parameter ::
      |  phid =  2.0e8,
      |  phin = -2.0e8,
-     |  ppolar = 0.
+     |  ppolar = 0.,
+     |  mp = 1.6726e-24 ! proton mass (g)
       integer :: k,i,lat,lonbeg,lonend,nlevs
-      real :: gmr,a,fed,fen,dbxdx,dbydy,tr,djmin,bdotdh_djbz2,
-     |  ubca, ubcb ! O+ upper boundary condition (were t2,t3)
-      real,dimension(lev0:lev1) :: bdotu1
-      real,dimension(lon0:lon1,lat0:lat1) ::
-     |  opflux     ! upward number flux of O+ (returned by sub oplus_flux) (t7)
-      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
-     |  hdz,              ! was s15
-     |  tphdz1,tphdz0,    ! were s13,s12 (using gmr)
-     |  djint,            ! was s11
-     |  divbz,            ! was s7 (DIV(B)+(DH*D*BZ)/(D*BZ)
-     |  hdzmbz,hdzpbz,    ! were s10,s9
-     |  tp1,              ! 0.5*(te+ti)
-     |  hdzi,bdotdh_djbz,
+      real(rp) :: a,djmin,gmr
+      real(rp),dimension(lon0:lon1,lat0:lat1) ::
+     |  phi,   opflux, ! upward number flux of O+ (returned by sub oplus_flux) (t7)
+     |  dbxdx, dbycdy, ! lon/lat derivatives of unit vector B
+     |  dvb_h,         ! horizontal divergence of unit vector B
+     |  ubca,  ubcb    ! O+ upper boundary condition (were t2,t3)
+      real(rp),dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
+     |  bdotdh_djbz,   ! (B(H).DEL(H))(D*BZ)
+     |  hdz,hdzi,      ! was s15
+     |  tp1,           ! 0.5*(te+ti)
+     |  djint,         ! was s11
+     |  tphdz1,tphdz0, ! were s13,s12 (using gmr)
+     |  bdotdh_djbz2,  ! (B(H).DEL(H))(D*BZ) / (D*BZ)
+     |  divbz,         ! was s7 (DIV(B)+(DH*D*BZ)/(D*BZ)
+     |  hdzmbz,hdzpbz, ! were s10,s9
      |  djint_tphdz0,djint_tphdz1,
-     |  djint_tphdz0_1,djint_tphdz1_1
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
-     |  o2_cm3,o1_cm3,he_cm3,n2_cm3,n2d_cm3,djbz
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) :: tmpf3d
+     |  djint_tphdz0_1,djint_tphdz1_1,
+     |  bdotu_m1,bdotu_p1,wii
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
+     |  tr,            ! Reduced temperature 0.5*(tn+ti)
+     |  vni,           ! O+ collision frequency
+     |  djbz,          ! D*BZ
+     |  o2_cm3,o1_cm3,he_cm3,n2_cm3,n2d_cm3
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) ::
+     |  tmpf3d
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
@@ -269,15 +282,16 @@
           else
             a = .5*(1.-cos(abs(rlatm(i,lat))*6.-pi/3.))
           endif
-          fed = phid*a
-          fen = phin*a
+!
           if (chi(i,lat) >= 100.*dtr) then
-            opflux(i,lat) = fen
+            phi(i,lat) = phin
           elseif (chi(i,lat) <= 80.*dtr) then
-            opflux(i,lat) = fed
+            phi(i,lat) = phid
           else
-            opflux(i,lat) = .5*(fed+fen+(fed-fen)*cos(chi(i,lat)*9.))
+            phi(i,lat) = .5*(phid+phin+(phid-phin)*cos(chi(i,lat)*9.))
           endif
+!
+          opflux(i,lat) = phi(i,lat)*a
 !
 ! Add ppolar if magnetic latitude >= 60 degrees:
           if (abs(rlatm(i,lat)) >= pi/3.)
@@ -297,10 +311,12 @@
       dvb = 0.
       do lat=lat0,lat1
         do i=lonbeg,lonend
-          dbxdx = (bx(i+1,lat)-bx(i-1,lat))/(2.*dlamda)
-          dbydy =
-     |      (cs(lat+1)*by(i,lat+1)-cs(lat-1)*by(i,lat-1))/(2.*dphi)
-          dvb(i,lat) = ((dbxdx+dbydy)/cs(lat)+2.*bz(i,lat))/re
+          dbxdx(i,lat) = (bx(i+1,lat)-bx(i-1,lat))/(2.*dlamda)
+          dbycdy(i,lat) =
+     |      (cs(lat+1)*by(i,lat+1)-
+     |       cs(lat-1)*by(i,lat-1))/(2.*dphi)
+          dvb_h(i,lat) = (dbxdx(i,lat)+dbycdy(i,lat))/(re*cs(lat))
+          dvb(i,lat) = dvb_h(i,lat)+2.*bz(i,lat)/re
         enddo ! i=lonbeg,lonend
       enddo ! lat=lat0,lat1
 !
@@ -318,19 +334,10 @@
 !
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
-          do k=lev0,lev1
-            o2_cm3(k,i,lat) = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
-            o1_cm3(k,i,lat) = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
-            he_cm3(k,i,lat) = xnmbar(k,i,lat)*he(k,i,lat)*rmassinv_he
-            n2_cm3(k,i,lat) = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
-            n2d_cm3(k,i,lat) = xnmbar(k,i,lat)*n2d(k,i,lat)*rmassinv_n2d
-          enddo ! k=lev0,lev1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
-!
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
           do k=lev0,lev1-1
+!
+! Plasma temperature:
+            tp(k,i,lat) = 0.5*(te(k,i,lat)+ti(k,i,lat))
 !
 ! Set reduced temperature (average of tn and ti)
 !
@@ -341,13 +348,30 @@
 !   change in O+ and Ne, and very small differences in NMF2,HMF2,TEC.
 !   Wenbin feels there should be larger changes in these fields
 !   as a consequence of fixing this bug.
-            tr = 0.5*(tn(k,i,lat)+ti(k,i,lat))
+            tr(k,i,lat) = 0.5*(tn(k,i,lat)+ti(k,i,lat))
+          enddo ! k=lev0,lev1-1
+!
+          tp(lev1,i,lat) = 2.*tp(lev1-1,i,lat)-tp(lev1-2,i,lat)
+          tr(lev1,i,lat) = 2.*tr(lev1-1,i,lat)-tr(lev1-2,i,lat)
+!
+          do k=lev0,lev1
+            o2_cm3(k,i,lat) = xnmbar(k,i,lat)*o2(k,i,lat)*rmassinv_o2
+            o1_cm3(k,i,lat) = xnmbar(k,i,lat)*o1(k,i,lat)*rmassinv_o1
+            he_cm3(k,i,lat) = xnmbar(k,i,lat)*he(k,i,lat)*rmassinv_he
+            n2_cm3(k,i,lat) = xnmbar(k,i,lat)*n2(k,i,lat)*rmassinv_n2
+            n2d_cm3(k,i,lat) = xnmbar(k,i,lat)*n2d(k,i,lat)*rmassinv_n2d
 !
 ! 8/28/13 btf: Use n2=1-o2-o-he, and include O+/He collision rate from Wenbin:
-            dj(k,i,lat) = 1.42E17/(18.1*o2_cm3(k,i,lat)+
-     |        3.6*he_cm3(k,i,lat)+18.6*n2_cm3(k,i,lat)+
-     |        o1_cm3(k,i,lat)*sqrt(tr)*(1.-0.064*log10(tr))**2*colfac)
-          enddo ! k=lev0,lev1-1
+            vni(k,i,lat) = 1e-10*
+     |        (6.64 *o2_cm3(k,i,lat)+
+     |         1.32 *he_cm3(k,i,lat)+
+     |         6.82 *n2_cm3(k,i,lat)+
+     |         0.367*o1_cm3(k,i,lat)*sqrt(tr(k,i,lat))*
+     |         (1.-0.064*log10(tr(k,i,lat)))**2*colfac)
+!
+! ambipolar diffusion coefficient
+            dj(k,i,lat) = boltz/(mp*rmass_op*vni(k,i,lat))
+          enddo ! k=lev0,lev1
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
 !
@@ -363,86 +387,43 @@
 !
 ! 2024/08 Haonan Wu: Change the original constant O+ diffusion cap
 !   to an altitude-dependent cap (use logistic function for now)
-      if (opdiffcap/=0. .and. opdiffrate/=0. .and.
+      if (opdiffcap/=0. .and.
+     |    opdiffrate/=0. .and.
      |    opdifflev/=spval) then
         do lat=lat0-2,lat1+2
           do i=lon0-2,lon1+2
-            do k=lev0,lev1-1
+            do k=lev0,lev1
               djmin = opdiffcap/(1+exp(opdiffrate*(zpmid(k)-opdifflev)))
               if (dj(k,i,lat) > djmin) dj(k,i,lat) = djmin
-            enddo ! k=lev0,lev1-1
+            enddo ! k=lev0,lev1
           enddo ! i=lon0-2,lon1+2
         enddo ! lat=lat0-2,lat1+2
       endif
 !
-!     do lat=lat0,lat1
-!       call addfld('DJ','DJ: Ambipolar Diffusion of O+',' ',
-!    |    dj(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
-!
-! djint = dj at interfaces:
       do lat=lat0,lat1
         do i=lon0,lon1
-          do k=lev0,lev1-2
-            djint(k+1,i,lat) = 0.5*(dj(k,i,lat)+dj(k+1,i,lat))
-          enddo ! k=lev0,lev1-2
-          djint(lev0,i,lat) = 1.5*dj(lev0  ,i,lat)-0.5*dj(lev0+1,i,lat)
-          djint(lev1,i,lat) = 1.5*dj(lev1-1,i,lat)-0.5*dj(lev1-2,i,lat)
-        enddo ! i=lon0,lon1
-!       call addfld('DJINT',' ',' ',djint(:,:,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-! Plasma temperature:
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
-            tp(k,i,lat) = 0.5*(te(k,i,lat)+ti(k,i,lat))
-          enddo ! k=lev0,lev1-1
-          tp(lev1,i,lat) = 2.*tp(lev1-1,i,lat)-tp(lev1-2,i,lat)
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
-!
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            tp1(k+1,i,lat) = tp(k,i,lat)
-          enddo ! k=lev0,lev1-1
-          tp1(lev0,i,lat) = 2.*tp(lev0,i,lat)-tp(lev0+1,i,lat)
-        enddo ! i=lon0,lon1
-!       call addfld('TP1',' ',' ',tp1(:,:,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
 !
 ! bdotu = B.U (s7)
-      do lat=lat0,lat1
-        do i=lon0,lon1
           do k=lev0,lev1-1
             bdotu(k,i,lat) =
      |        bx(i,lat)*un(k,i,lat)+by(i,lat)*vn(k,i,lat)+
      |        scht(k,i,lat)*bz(i,lat)*0.5*(w(k,i,lat)+w(k+1,i,lat))
           enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('BDOTU',' ',' ',bdotu(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
+          bdotu(lev1,i,lat) = 2.*bdotu(lev1-1,i,lat)-bdotu(lev1-2,i,lat)
 !
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             djbz(k,i,lat) = dj(k,i,lat)*bz(i,lat)
-          enddo ! k=lev0,lev1-1
+          enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
 !
 ! Fill up halo points of bdotu, djbz (used in bdotdh calls)
       do lat=lat0,lat1
         do i=lon0,lon1
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             tmpf3d(k,i,lat,1) = bdotu(k,i,lat)
             tmpf3d(k,i,lat,2) = djbz(k,i,lat)
-          enddo ! k=lev0,lev1-1
+          enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
       call mp_polelats_f3d(tmpf3d(:,lon0:lon1,:,:),
@@ -451,214 +432,137 @@
       call mp_bndlons_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2,0)
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             bdotu(k,i,lat) = tmpf3d(k,i,lat,1)
             djbz(k,i,lat) = tmpf3d(k,i,lat,2)
-          enddo ! k=lev0,lev1-1
+          enddo ! k=lev0,lev1
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
+!
+      call bdotdh(djbz,bdotdh_djbz,lev0,lev1,lon0,lon1,lat0,lat1)
+!
+! gmr = G*M(O+)/(2.*R)
+      gmr = grav*rmass_op/(2.*gask)
 !
       do lat=lat0,lat1
         do i=lon0,lon1
           do k=lev0,lev1
             hdz(k,i,lat) = 1./(scht(k,i,lat)*dz)
           enddo ! k=lev0,lev1
-        enddo ! i=lon0,lon1
-!       call addfld('HDZ',' ',' ',hdz(:,:,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
 !
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-2
+          do k=lev0,lev1-1
+            tp1(k+1,i,lat) = tp(k,i,lat)
+            bdotu_m1(k+1,i,lat) = bdotu(k,i,lat)
+            bdotu_p1(k,i,lat) = bdotu(k+1,i,lat)
             hdzi(k+1,i,lat) = 0.5*(hdz(k,i,lat)+hdz(k+1,i,lat))
-          enddo ! k=lev0,lev1-2
+            djint(k+1,i,lat) = 0.5*(dj(k,i,lat)+dj(k+1,i,lat))
+            wii(k,i,lat) = 0.5*(wi(k,i,lat)+wi(k+1,i,lat))
+          enddo ! k=lev0,lev1-1
 !
-! Upper and lower boundaries:
-          hdzi(lev0,i,lat) = 1.5*hdz(lev0  ,i,lat)-0.5*hdz(lev0+1,i,lat)
-          hdzi(lev1,i,lat) = 1.5*hdz(lev1-1,i,lat)-0.5*hdz(lev1-2,i,lat)
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
+          tp1(lev0,i,lat) = 2.*tp(lev0,i,lat)-tp(lev0+1,i,lat)
+          bdotu_m1(lev0,i,lat) =
+     |      2.*bdotu(lev0,i,lat)-bdotu(lev0+1,i,lat)
+          bdotu_p1(lev1,i,lat) =
+     |      2.*bdotu(lev1,i,lat)-bdotu(lev1-1,i,lat)
+          hdzi(lev0,i,lat) = 1.5*hdz(lev0,i,lat)-0.5*hdz(lev0+1,i,lat)
+          djint(lev0,i,lat) = 1.5*dj(lev0,i,lat)-0.5*dj(lev0+1,i,lat)
+          wii(lev1,i,lat) = 1.5*wi(lev1,i,lat)-0.5*wi(lev1-1,i,lat)
 !
-! gmr = G*M(O+)/(2.*R)
-      gmr = grav*rmass_op/(2.*gask)
-      do lat=lat0,lat1
-        do i=lon0,lon1
           do k=lev0,lev1
             tphdz1(k,i,lat) = 2.*tp (k,i,lat)*hdzi(k,i,lat)+gmr ! s13
             tphdz0(k,i,lat) = 2.*tp1(k,i,lat)*hdzi(k,i,lat)-gmr ! s12
-          enddo ! k=lev0,lev1
-        enddo ! i=lon0,lon1
-!       call addfld('TPHDZ1',' ',' ',tphdz1(:,:,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('TPHDZ0',' ',' ',tphdz0(:,:,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-      call bdotdh(djbz,bdotdh_djbz,lev0,lev1,lon0,lon1,lat0,lat1)
 !
 ! divbz = (DIV(B)+(DH*D*BZ)/(D*BZ) (was s7)
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            bdotdh_djbz2 = bdotdh_djbz(k,i,lat)/djbz(k,i,lat)
-            divbz(k,i,lat) = (dvb(i,lat)+bdotdh_djbz2)/bz(i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('DIVBZ',' ',' ',divbz(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
+            bdotdh_djbz2(k,i,lat) = bdotdh_djbz(k,i,lat)/djbz(k,i,lat)
+            divbz(k,i,lat) =
+     |        (dvb(i,lat)+bdotdh_djbz2(k,i,lat))/bz(i,lat)
 !
 ! hdzmbz = (1./(H*DZ)-(DIV(B)+DH*D*BZ/(D*BZ))/(2*BZ))*BZ**2 (was s10)
 ! hdzpbz = (1./(H*DZ)+(DIV(B)+DH*D*BZ/(D*BZ))/(2*BZ))*BZ**2 (was s9 )
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
             hdzmbz(k,i,lat) =
      |        (hdz(k,i,lat)-0.5*divbz(k,i,lat))*bz(i,lat)**2
             hdzpbz(k,i,lat) =
      |        (hdz(k,i,lat)+0.5*divbz(k,i,lat))*bz(i,lat)**2
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('HDZMBZ' ,' ',' ',hdzmbz(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('HDZPBZ' ,' ',' ',hdzpbz(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
 !
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1
             djint_tphdz0(k,i,lat) = djint(k,i,lat)*tphdz0(k,i,lat)
             djint_tphdz1(k,i,lat) = djint(k,i,lat)*tphdz1(k,i,lat)
           enddo ! k=lev0,lev1
+!
           do k=lev0,lev1-1
             djint_tphdz0_1(k,i,lat) = djint_tphdz0(k+1,i,lat)
             djint_tphdz1_1(k,i,lat) = djint_tphdz1(k+1,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
 !
-! Begin coefficients p_coeff, q_coeff, r_coeff  (s1,s2,s3)
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            diffp(k,i,lat) =   hdzmbz(k,i,lat)*djint_tphdz0  (k,i,lat)
-            diffq(k,i,lat) = -(hdzpbz(k,i,lat)*djint_tphdz0_1(k,i,lat)+
-     |                         hdzmbz(k,i,lat)*djint_tphdz1  (k,i,lat))
-            diffr(k,i,lat) =   hdzpbz(k,i,lat)*djint_tphdz1_1(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('P_COEFF0',' ',' ',
-!    |    diffp(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('Q_COEFF0',' ',' ',
-!    |    diffq(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('R_COEFF0',' ',' ',
-!    |    diffr(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-! Continue coefficients with vertical ion velocity:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            driftp(k,i,lat) =
-     |        0.5*(wi(k,i,lat)+wi(k+1,i,lat))*0.5*hdz(k,i,lat)
-            driftq(k,i,lat) = -0.5*(wi(k,i,lat)+wi(k+1,i,lat))*6./re
-            driftr(k,i,lat) =
-     |        -0.5*(wi(k,i,lat)+wi(k+1,i,lat))*0.5*hdz(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('P_COEFF1',' ',' ',
-!    |    driftp(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('Q_COEFF1',' ',' ',
-!    |    driftq(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('R_COEFF1',' ',' ',
-!    |    driftr(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-! Continue coefficients with vertical neutral wind:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-2
-            bdotu1(k+1) = bdotu(k,i,lat)
-          enddo ! k=lev0,lev1-2
-          bdotu1(lev0) = 2.*bdotu(lev0,i,lat)-bdotu(lev0+1,i,lat)
-          do k=lev0,lev1-1
-            windp(k,i,lat) = bz(i,lat)*bdotu1(k)*0.5*hdz(k,i,lat)
-          enddo ! k=lev0,lev1-1
-!
-          do k=lev0,lev1-1
-            windq(k,i,lat) = -bdotu(k,i,lat)*dvb(i,lat)
-          enddo ! k=lev0,lev1-1
-!
-          do k=lev0,lev1-2
-            bdotu1(k) = bdotu(k+1,i,lat)
-          enddo ! k=lev0,lev1-2
-          bdotu1(lev1-1) = 2.*bdotu(lev1-1,i,lat)-bdotu(lev1-2,i,lat)
-          do k=lev0,lev1-1
-            windr(k,i,lat) = -bz(i,lat)*bdotu1(k)*0.5*hdz(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('P_COEFF2',' ',' ',
-!    |    windp(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('Q_COEFF2',' ',' ',
-!    |    windq(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('R_COEFF2',' ',' ',
-!    |    windr(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-! Sources and sinks (xiop2p and xiop2d are outputs):
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
+! xiop2p and xiop2d are outputs:
             xiop2p(k,i,lat) =
      |        0.5*(qop2p(k,i,lat)+qop2p(k+1,i,lat))/
-     |        ((rk16+rk17)*n2_cm3(k,i,lat)+rk18*o1_cm3(k,i,lat)+
-     |        (rk19(k,i,lat)+rk20(k,i,lat))*ne(k,i,lat)+rk21+rk22)
-!
+     |        ((rk16+rk17)*n2_cm3(k,i,lat)+
+     |         rk18*o1_cm3(k,i,lat)+
+     |         (rk19(k,i,lat)+rk20(k,i,lat))*ne(k,i,lat)+
+     |         rk21+rk22)
             xiop2d(k,i,lat) =
      |        (0.5*(qop2d(k,i,lat)+qop2d(k+1,i,lat))+
-     |        (rk20(k,i,lat)*ne(k,i,lat)+rk22)*xiop2p(k,i,lat))/
-     |        (rk23*n2_cm3(k,i,lat)+rk24*o1_cm3(k,i,lat)+
-     |        rk26*o2_cm3(k,i,lat)+
-     |        rk25(k,i,lat)*ne(k,i,lat)+rk27)
+     |         rk20(k,i,lat)*xiop2p(k,i,lat)*ne(k,i,lat)+
+     |         rk22*xiop2p(k,i,lat))/
+     |        (rk23*n2_cm3(k,i,lat)+
+     |         rk24*o1_cm3(k,i,lat)+
+     |         rk25(k,i,lat)*ne(k,i,lat)+
+     |         rk26*o2_cm3(k,i,lat)+
+     |         rk27)
 !
-            op_loss(k,i,lat) = rk1(k,i,lat)*o2_cm3(k,i,lat)+
-     |        rk2(k,i,lat)*n2_cm3(k,i,lat)+rk10*n2d_cm3(k,i,lat)
-!
+! Sources and sinks
             op_prod(k,i,lat) =
      |        0.5*(qop(k,i,lat)+qop(k+1,i,lat))+
-     |        (rk19(k,i,lat)*ne(k,i,lat)+rk21)*xiop2p(k,i,lat)+
-     |        (rk25(k,i,lat)*ne(k,i,lat)+rk27)*xiop2d(k,i,lat)+
-     |        (rk18*xiop2p(k,i,lat)+rk24*xiop2d(k,i,lat))*
-     |        o1_cm3(k,i,lat)
+     |        rk18*xiop2p(k,i,lat)*o1_cm3(k,i,lat)+
+     |        rk19(k,i,lat)*xiop2p(k,i,lat)*ne(k,i,lat)+
+     |        rk21*xiop2p(k,i,lat)+
+     |        rk24*xiop2d(k,i,lat)*o1_cm3(k,i,lat)+
+     |        rk25(k,i,lat)*xiop2d(k,i,lat)*ne(k,i,lat)+
+     |        rk27*xiop2d(k,i,lat)
+            op_loss(k,i,lat) =
+     |        rk1(k,i,lat)*o2_cm3(k,i,lat)+
+     |        rk2(k,i,lat)*n2_cm3(k,i,lat)+
+     |        rk10*n2d_cm3(k,i,lat)
           enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('XIOP2P',' ',' ',xiop2p(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('XIOP2D',' ',' ',xiop2d(lev0:lev1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!       call addfld('OP_LOSS_COEF',' ',' ',
-!    |    op_loss(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('OP_PROD',' ',' ',
-!    |    op_prod(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
+!
+          djint_tphdz0_1(lev1,i,lat) =
+     |      2.*djint_tphdz0(lev1,i,lat)-djint_tphdz0(lev1-1,i,lat)
+          djint_tphdz1_1(lev1,i,lat) =
+     |      2.*djint_tphdz1(lev1,i,lat)-djint_tphdz1(lev1-1,i,lat)
+          xiop2p(lev1,i,lat) =
+     |      2.*xiop2p(lev1-1,i,lat)-xiop2p(lev1-2,i,lat)
+          xiop2d(lev1,i,lat) =
+     |      2.*xiop2d(lev1-1,i,lat)-xiop2d(lev1-2,i,lat)
+          op_prod(lev1,i,lat) =
+     |      2.*op_prod(lev1-1,i,lat)-op_prod(lev1-2,i,lat)
+          op_loss(lev1,i,lat) =
+     |      2.*op_loss(lev1-1,i,lat)-op_loss(lev1-2,i,lat)
+!
+          do k=lev0,lev1
+!
+! Begin coefficients p_coeff, q_coeff, r_coeff  (s1,s2,s3)
+            diffp(k,i,lat) =
+     |          hdzmbz(k,i,lat)*djint_tphdz0  (k,i,lat)
+            diffq(k,i,lat) =
+     |        -(hdzpbz(k,i,lat)*djint_tphdz0_1(k,i,lat)+
+     |          hdzmbz(k,i,lat)*djint_tphdz1  (k,i,lat))
+            diffr(k,i,lat) =
+     |          hdzpbz(k,i,lat)*djint_tphdz1_1(k,i,lat)
+!
+! Continue coefficients with vertical ion velocity:
+            driftp(k,i,lat) = wii(k,i,lat)*0.5*hdz(k,i,lat)
+            driftq(k,i,lat) = -wii(k,i,lat)*6./re
+            driftr(k,i,lat) = -wii(k,i,lat)*0.5*hdz(k,i,lat)
+!
+! Continue coefficients with vertical neutral wind:
+            windp(k,i,lat) =
+     |        bz(i,lat)*bdotu_m1(k,i,lat)*0.5*hdz(k,i,lat)
+            windq(k,i,lat) = -bdotu(k,i,lat)*dvb(i,lat)
+            windr(k,i,lat) =
+     |        -bz(i,lat)*bdotu_p1(k,i,lat)*0.5*hdz(k,i,lat)
+          enddo ! k=lev0,lev1
 !
 ! Additions to Q coefficients, Sinks:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             p_coeff(k,i,lat) =
      |        diffp(k,i,lat)+driftp(k,i,lat)+windp(k,i,lat)
             q_coeff(k,i,lat) =
@@ -666,37 +570,58 @@
      |        dtx2inv*nstep_sub-op_loss(k,i,lat)
             r_coeff(k,i,lat) =
      |        diffr(k,i,lat)+driftr(k,i,lat)+windr(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
+          enddo ! k=lev0,lev1
 !
 ! Upper boundary condition for O+:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          ubcb = -bz(i,lat)**2*djint_tphdz0(lev1,i,lat) ! t3
-          ubca = -bz(i,lat)**2*djint_tphdz1(lev1,i,lat) ! t2
+          ubcb(i,lat) = bz(i,lat)**2*djint_tphdz0(lev1,i,lat) ! t3
+          ubca(i,lat) = bz(i,lat)**2*djint_tphdz1(lev1,i,lat) ! t2
 !
 ! Q = Q+B/A*R
           q_coeff(lev1-1,i,lat) = q_coeff(lev1-1,i,lat)+
-     |      ubcb/ubca*r_coeff(lev1-1,i,lat)
+     |      ubcb(i,lat)/ubca(i,lat)*r_coeff(lev1-1,i,lat)
 !
 ! F = F-R/A*PHI
-          ubcrhs(i,lat) = opflux(i,lat)*r_coeff(lev1-1,i,lat)/ubca
+          ubcrhs(i,lat) = -opflux(i,lat)*
+     |      r_coeff(lev1-1,i,lat)/ubca(i,lat)
           r_coeff(lev1-1,i,lat) = 0.
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
 !
 ! Lower boundary condition N(O+) = Q/L:
-      do lat=lat0,lat1
-        do i=lon0,lon1
           q_coeff(lev0,i,lat) = q_coeff(lev0,i,lat)-p_coeff(lev0,i,lat)
           lbcrhs(i,lat) = 2.*p_coeff(lev0,i,lat)*qop(lev0,i,lat)/
      |      (1.5*op_loss(lev0,i,lat)-0.5*op_loss(lev0+1,i,lat))
           p_coeff(lev0,i,lat) = 0.
         enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
 !
-!     do lat=lat0,lat1
+!       call addfld('TR','TR: reduced temperature (0.5*(tn+ti))',' ',
+!    |    tr(:,lon0:lon1,lat),'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('DJ','DJ: Ambipolar Diffusion of O+',' ',
+!    |    dj(:,lon0:lon1,lat),'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('BDOTU' ,' ',' ',bdotu(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('HDZ',' ',' ',hdz(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('TP1',' ',' ',tp1(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('DJINT',' ',' ',djint(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('TPHDZ1',' ',' ',tphdz1(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('TPHDZ0',' ',' ',tphdz0(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('DIVBZ',' ',' ',divbz(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('HDZMBZ' ,' ',' ',hdzmbz(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('HDZPBZ' ,' ',' ',hdzpbz(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('XIOP2P',' ',' ',xiop2p(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('XIOP2D',' ',' ',xiop2d(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_LOSS_COEF',' ',' ',op_loss(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OP_PROD',' ',' ',op_prod(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
 !       call addfld('P_COEFF',' ',' ',
 !    |    p_coeff(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
@@ -706,7 +631,7 @@
 !       call addfld('R_COEFF',' ',' ',
 !    |    r_coeff(lev0:lev1-1,lon0:lon1,lat),
 !    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
+      enddo ! lat=lat0,lat1
 !
       end subroutine prep_oplus
 !-----------------------------------------------------------------------
@@ -715,8 +640,10 @@
 !
 ! Shapiro smoother for O+
 !
+      use params_module,only: rp
       use cons_module,only: shapiro
       use input_module,only: nstep_sub
+      use addfld_module,only: addfld
 !
 ! Args:
       integer,intent(in) ::
@@ -725,65 +652,62 @@
      |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
 !
 ! Input fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(in) ::
      |  optm1      ! O+ at time n-1
 !
 ! Output fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(out) ::
      |  optm1_smooth ! op at time n-1, with shapiro smoother (was s1)
 !
 ! Local:
       integer :: k,i,lat
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0:lat1) ::
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0:lat1) ::
      |  optm1_smooth1 ! op at time n-1, with shapiro smoother (was s1)
-!
-! Save inputs to secondary history file:
-!
-!     do lat=lat0,lat1
-!       call addfld('OPTM1',' ',' ',optm1(:,lon0:lon1,lat),
-!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
 !
 ! Shapiro smoother: optm1 is O+ at time n-1 (optm1_smooth was s1)
 ! optm1_smooth will be used in explicit terms below.
       do lat=lat0,lat1
         do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             optm1_smooth1(k,i,lat) = optm1(k,i,lat)-
      |        shapiro/nstep_sub*
      |        (optm1(k,i,lat+2)+optm1(k,i,lat-2)-
      |        4.*(optm1(k,i,lat+1)+optm1(k,i,lat-1))+
      |        6.*optm1(k,i,lat))
-          enddo ! k=lev0,lev1-1
+          enddo ! k=lev0,lev1
         enddo ! i=lon0-2,lon1+2
-!       call addfld('OPTM1_SM0' ,' ',' ',
-!    |    optm1_smooth1(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
 !
 ! Boundary longitudes for optm1_smooth1 were obtained after first
 ! latitude scan above.
-!
       do lat=lat0,lat1
         do i=lon0,lon1
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             optm1_smooth(k,i,lat) = optm1_smooth1(k,i,lat)-
      |        shapiro/nstep_sub*
      |        (optm1_smooth1(k,i+2,lat)+optm1_smooth1(k,i-2,lat)-
      |        4.*(optm1_smooth1(k,i+1,lat)+optm1_smooth1(k,i-1,lat))+
      |        6.*optm1_smooth1(k,i,lat))
-          enddo ! k=lev0,lev1-1
+          enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
-!       call addfld('OPTM1_SM1' ,' ',' ',
-!    |    optm1_smooth(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
       enddo ! lat=lat0,lat1
+!
+!     do lat=lat0,lat1
+!       call addfld('OPTM1',' ',' ',optm1(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OPTM1_SM0' ,' ',' ',
+!    |    optm1_smooth1(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OPTM1_SM1' ,' ',' ',
+!    |    optm1_smooth(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
 !
       end subroutine smooth_oplus
 !-----------------------------------------------------------------------
-      subroutine iterate_oplus(dvb,ubcrhs,lbcrhs,dj,tp,bdotu,
+      subroutine iterate_oplus(dvb,ubcrhs,lbcrhs,tp,dj,bdotu,
      |  optm1_smooth,op_prod,ui,vi,scht,p_coeff,q_coeff,r_coeff,
      |  op,opout,diffj,diffexp,vdotn_h,bdotdh_bvel,
      |  lev0,lev1,lon0,lon1,lat0,lat1)
@@ -792,7 +716,7 @@
 ! Outputs are opout, diffj, diffexp, vdotn_h, bdotdh_bvel,
 ! all other args are input.
 !
-      use params_module,only: nlonp4,dz
+      use params_module,only: nlonp4,dz,rp
       use cons_module,only: rmass_op,gask,grav,re,cs,dphi,dlamda,dtx2inv
       use input_module,only: nstep_sub
       use magfield_module,only: bz,bmod2 ! (nlonp4,-1:nlat+2)
@@ -807,15 +731,15 @@
      |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
 !
 ! Input fields (full 2d task subdomain):
-      real,dimension(lon0-2:lon1+2,lat0-2:lat1+2),intent(in) ::
+      real(rp),dimension(lon0-2:lon1+2,lat0-2:lat1+2),intent(in) ::
      |  dvb,        ! output of sub divb
      |  ubcrhs,lbcrhs
 !
 ! Input fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(in) ::
-     |  dj,          ! diffusion coefficients (s13,s14,s15)
      |  tp,          ! Plasma temperature (te+ti)
+     |  dj,          ! diffusion coefficients (s13,s14,s15)
      |  bdotu,       ! was s7 (B.U)
      |  optm1_smooth,! op at time n-1, with shapiro smoother (was s1)
      |  op_prod,
@@ -825,7 +749,7 @@
      |  op           ! O+ ion
 !
 ! Output fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(out) ::
      |  opout,    ! O+ output for next timestep
      |  diffj,    ! (D/(H*DZ)*2.*TP+M*G/R)*N(O+) (s7,s8,s9)
@@ -833,18 +757,19 @@
 !
 ! Local:
       integer :: k,i,lat,ier,nlevs
-      real :: mgr
-      real,dimension(lev0:lev1) :: dtpop,dbdotdh_opj
-      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
-     |  bdzdvb_op,        ! was s7
-     |  explicit,         ! was s4
+      real(rp) :: mgr
+      real(rp),dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
+     |  uii,vii,dtpopdz,dbdotdh_opjdz,
      |  bdotdh_op,        ! (b(h)*del(h))*phi
-     |  bdotdh_diff       ! (b(h)*del(h))*phi
+     |  bdotdh_diff,      ! (b(h)*del(h))*phi
+     |  bdzdvb_op,        ! was s7
+     |  explicit          ! was s4
 !
 ! Local fields at 3d subdomain (must be 3d to bridge latitude scans):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
-     |  bvel,tpop,op_bmod2,bdotdh_opj ! (b(h)*del(h))*phi
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) :: tmpf3d
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
+     |  tpop,bvel,opb,bdotdh_opj ! (b(h)*del(h))*phi
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) ::
+     |  tmpf3d
 !
 #ifdef VT
 !     code = 113 ; state = 'oplus' ; activity='ModelCode'
@@ -854,62 +779,40 @@
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
 !
-! Plasma temperature times O+
+      mgr = rmass_op*grav/gask
+!
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
-            tpop(k,i,lat) = tp(k,i,lat)*op(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
+          do k=lev0,lev1
 !
-!     do lat=lat0,lat1
-!       call addfld('TPJ','TP after times OP',' ',
-!    |    tpop(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
+! Plasma temperature times O+
+            tpop(k,i,lat) = tp(k,i,lat)*op(k,i,lat)
+!
+! bvel @ j   = (B.U)*N(O+)      (J) (was s7)
+            bvel(k,i,lat) = bdotu(k,i,lat)*op(k,i,lat)
+          enddo ! k=lev0,lev1
 !
 ! Evaluates ans = (d/(h*dz)*tp+m*g/r)*en
-      mgr = rmass_op*grav/gask
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
-          do k=lev0+1,lev1-2
-            dtpop(k) = (tpop(k+1,i,lat)-tpop(k-1,i,lat))/2.
-          enddo ! k=lev0+1,lev1-2
+          do k=lev0+1,lev1-1
+            dtpopdz(k,i,lat) = (tpop(k+1,i,lat)-tpop(k-1,i,lat))/(2.*dz)
+          enddo ! k=lev0+1,lev1-1
 !
 ! Upper and lower boundaries:
-          dtpop(lev1-1) = tpop(lev1-1,i,lat)-tpop(lev1-2,i,lat)
-          dtpop(lev0) = tpop(lev0+1,i,lat)-tpop(lev0,i,lat)
+          dtpopdz(lev1,i,lat) = (tpop(lev1,i,lat)-tpop(lev1-1,i,lat))/dz
+          dtpopdz(lev0,i,lat) = (tpop(lev0+1,i,lat)-tpop(lev0,i,lat))/dz
 !
-          do k=lev0,lev1-1
-            diffj(k,i,lat) = 1./(scht(k,i,lat)*dz)*2.*dtpop(k)+
+          do k=lev0,lev1
+            diffj(k,i,lat) = 2.*dtpopdz(k,i,lat)/scht(k,i,lat)+
      |        mgr*op(k,i,lat)
-          enddo ! k=lev0,lev1-1
+          enddo ! k=lev0,lev1
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
 !
-!     do lat=lat0,lat1
-!       call addfld('DIFFJ','DIFFJ after diffus',' ',
-!    |    diffj(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
+      call bdotdh(bvel,bdotdh_bvel(:,lon0:lon1,lat0:lat1),
+     |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
 ! bdotdh_op = (B(H).DEL(H))*(D/(H*DZ)*TP+M*G/R)*N(O+)
-! then bdotdh_op = d*bz*bdotdh_op
-!
       call bdotdh(diffj,bdotdh_op,lev0,lev1,lon0,lon1,lat0,lat1)
-!
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            bdotdh_op(k,i,lat) =
-     |        dj(k,i,lat)*bz(i,lat)*bdotdh_op(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('BDOTDH_1',' ',' ',
-!    |    bdotdh_op(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
 !
 ! bdotdh_opj   = (B(H).DEL(H))*2.*TP*N(O+)      (J)
       call bdotdh(2.*tpop,bdotdh_opj(:,lon0:lon1,lat0:lat1),
@@ -917,29 +820,19 @@
 !
       do lat=lat0,lat1
         do i=lon0,lon1
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             bdotdh_opj(k,i,lat) = bdotdh_opj(k,i,lat)*dj(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('BDOTDH_2',' ',' ',
-!    |    bdotdh_opj(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
-!
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            op_bmod2(k,i,lat) = op(k,i,lat)/bmod2(i,lat)**2
-          enddo ! k=lev0,lev1-1
+            opb(k,i,lat) = op(k,i,lat)/bmod2(i,lat)**2
+          enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
 !
       do lat=lat0,lat1
         do i=lon0,lon1
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             tmpf3d(k,i,lat,1) = bdotdh_opj(k,i,lat)
-            tmpf3d(k,i,lat,2) = op_bmod2(k,i,lat)
-          enddo ! k=lev0,lev1-1
+            tmpf3d(k,i,lat,2) = opb(k,i,lat)
+          enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
       call mp_polelats_f3d(tmpf3d(:,lon0:lon1,:,:),
@@ -948,10 +841,10 @@
       call mp_bndlons_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2,0)
       do lat=lat0-2,lat1+2
         do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             bdotdh_opj(k,i,lat) = tmpf3d(k,i,lat,1)
-            op_bmod2(k,i,lat) = tmpf3d(k,i,lat,2)
-          enddo ! k=lev0,lev1-1
+            opb(k,i,lat) = tmpf3d(k,i,lat,2)
+          enddo ! k=lev0,lev1
         enddo ! i=lon0-2,lon1+2
       enddo ! lat=lat0-2,lat1+2
 !
@@ -960,112 +853,65 @@
 ! (periodic points apparently not necessary for bdotdh_diff)
       call bdotdh(bdotdh_opj,bdotdh_diff,lev0,lev1,lon0,lon1,lat0,lat1)
 !
-!     do lat=lat0,lat1
-!       call addfld('BDOT_DIF',' ',' ',
-!    |    bdotdh_diff(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1-1
+            uii(k,i,lat) = 0.5*(ui(k,i,lat)+ui(k+1,i,lat))
+            vii(k,i,lat) = 0.5*(vi(k,i,lat)+vi(k+1,i,lat))
+          enddo ! k=lev0,lev1-1
+          uii(lev1,i,lat) = 1.5*ui(lev1,i,lat)-0.5*ui(lev1-1,i,lat)
+          vii(lev1,i,lat) = 1.5*vi(lev1,i,lat)-0.5*vi(lev1-1,i,lat)
 !
 ! bdzdvb_op = (BZ*D/(H*DZ)+DIV(*B))*S2
 !
 ! Evaluates (bz*d/(h*dz)+divb)*phi
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0+1,lev1-2
-            dbdotdh_opj(k) =
-     |        (bdotdh_opj(k+1,i,lat)-bdotdh_opj(k-1,i,lat))/2.
-          enddo ! k=lev0+1,lev1-2
+          do k=lev0+1,lev1-1
+            dbdotdh_opjdz(k,i,lat) =
+     |        (bdotdh_opj(k+1,i,lat)-bdotdh_opj(k-1,i,lat))/(2.*dz)
+          enddo ! k=lev0+1,lev1-1
 !
 ! Upper and lower boundaries:
-          dbdotdh_opj(lev1-1) =
-     |      bdotdh_opj(lev1-1,i,lat)-bdotdh_opj(lev1-2,i,lat)
-          dbdotdh_opj(lev0) =
-     |      bdotdh_opj(lev0+1,i,lat)-bdotdh_opj(lev0,i,lat)
+          dbdotdh_opjdz(lev1,i,lat) =
+     |      (bdotdh_opj(lev1,i,lat)-bdotdh_opj(lev1-1,i,lat))/dz
+          dbdotdh_opjdz(lev0,i,lat) =
+     |      (bdotdh_opj(lev0+1,i,lat)-bdotdh_opj(lev0,i,lat))/dz
 !
-          do k=lev0,lev1-1
+          do k=lev0,lev1
             bdzdvb_op(k,i,lat) =
-     |        bz(i,lat)/(scht(k,i,lat)*dz)*dbdotdh_opj(k)+
+     |        bz(i,lat)*dbdotdh_opjdz(k,i,lat)/scht(k,i,lat)+
      |        dvb(i,lat)*bdotdh_opj(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('BDZDVB',' ',' ',bdzdvb_op(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
 !
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
+! bdotdh_op = (B(H).DEL(H))*(D/(H*DZ)*TP+M*G/R)*N(O+)
+! then bdotdh_op = d*bz*bdotdh_op
+            bdotdh_op(k,i,lat) =
+     |        dj(k,i,lat)*bz(i,lat)*bdotdh_op(k,i,lat)
+!
             diffexp(k,i,lat) =
      |        bdzdvb_op(k,i,lat)+bdotdh_diff(k,i,lat)+bdotdh_op(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
-!
-! bvel @ j   = (B.U)*N(O+)      (J) (was s7)
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
-          do k=lev0,lev1-1
-            bvel(k,i,lat) = bdotu(k,i,lat)*op(k,i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
-!
-!     do lat=lat0,lat1
-!       call addfld('BVEL_J',' ',' ',bvel(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
-!
-      call bdotdh(bvel,bdotdh_bvel(:,lon0:lon1,lat0:lat1),
-     |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
 ! Note if input flag DYNAMO<=0, then ui,vi,wi velocities will be zero.
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
             vdotn_h(k,i,lat) = bmod2(i,lat)**2/(2.*re)*
-     |        (1./(cs(lat)*dlamda)*
-     |        0.5*(ui(k,i,lat)+ui(k+1,i,lat))*
-     |        (op_bmod2(k,i+1,lat)-op_bmod2(k,i-1,lat))+
-!
-     |        1./dphi*
-     |        0.5*(vi(k,i,lat)+vi(k+1,i,lat))*
-     |        (op_bmod2(k,i,lat+1)-op_bmod2(k,i,lat-1)))
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
+     |        (uii(k,i,lat)/(cs(lat)*dlamda)*
+     |         (opb(k,i+1,lat)-opb(k,i-1,lat))+
+     |         vii(k,i,lat)/dphi*
+     |         (opb(k,i,lat+1)-opb(k,i,lat-1)))
 !
 ! Collect explicit terms:
 ! Sum O+ at time n-1 to explicit terms: N(O+)/(2*DT) (N-1) (was s4)
 ! Add source term to RHS (explicit terms):
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            explicit(k,i,lat) = -diffexp(k,i,lat)+
+            explicit(k,i,lat) =
      |        vdotn_h(k,i,lat)+bdotdh_bvel(k,i,lat)-
-     |        optm1_smooth(k,i,lat)*dtx2inv*nstep_sub-
-     |        op_prod(k,i,lat)
+     |        diffexp(k,i,lat)-op_prod(k,i,lat)-
+     |        optm1_smooth(k,i,lat)*dtx2inv*nstep_sub
           enddo ! k=lev0,lev1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
 !
 ! Upper boundary condition for O+ (F = F-R/A*PHI):
-      do lat=lat0,lat1
-        do i=lon0,lon1
           explicit(lev1-1,i,lat) = explicit(lev1-1,i,lat)-ubcrhs(i,lat)
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
 !
 ! Lower boundary condition N(O+) = Q/L:
-      do lat=lat0,lat1
-        do i=lon0,lon1
           explicit(lev0,i,lat) = explicit(lev0,i,lat)-lbcrhs(i,lat)
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
-!
-!     do lat=lat0,lat1
-!       call addfld('EXPLIC',' ',' ',explicit(lev0:lev1-1,:,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!     enddo ! lat=lat0,lat1
 !
 ! Tridiagonal solver returns updated O+ in opout (all other args are input):
       do lat=lat0,lat1
@@ -1076,13 +922,38 @@
      |    explicit(:,lon0:lon1,lat),
      |    opout(:,lon0:lon1,lat),
      |    lev0,lev1,lev0,lev1-1,lon0,lon1,nlonp4,lat,0)
-!       call addfld('OP_SOLV',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!
+! Upper boundary:
+        do i=lon0,lon1
+          opout(lev1,i,lat) = 2.*opout(lev1-1,i,lat)-opout(lev1-2,i,lat)
+        enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
 !
 ! Periodic points for outputs:
-        call mp_periodic_f3d(opout(:,lon0:lon1,lat0:lat1),
-     |    lev0,lev1,lon0,lon1,lat0,lat1,1)
+      call mp_periodic_f3d(opout(:,lon0:lon1,lat0:lat1),
+     |  lev0,lev1,lon0,lon1,lat0,lat1,1)
+!
+!     do lat=lat0,lat1
+!       call addfld('TPJ','TP after times OP',' ',tpop(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('BVEL_J',' ',' ',bvel(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('DIFFJ','DIFFJ after diffus',' ',
+!    |    diffj(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('BDOTDH_1',' ',' ',bdotdh_op(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('BDOTDH_2',' ',' ',bdotdh_opj(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('BDOT_DIF',' ',' ',bdotdh_diff(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('BDZDVB',' ',' ',bdzdvb_op(:,:,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('EXPLIC',' ',' ',explicit(lev0:lev1-1,:,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OP_SOLV',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
+!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!     enddo ! lat=lat0,lat1
 !
 #ifdef VT
 !     code = 113 ; state = 'oplus' ; activity='ModelCode'
@@ -1097,10 +968,11 @@
 ! Post-processing time smoothing.
 ! This is called after filter_op
 !
-      use params_module,only: zpmid,spval  ! for O+ minimum
+      use params_module,only: zpmid,spval,rp  ! for O+ minimum
       use cons_module,only: rtd,dtsmooth,dtsmooth_div2
       use input_module,only: opfloor,oprate,oplev,oplatwidth
       use magfield_module,only: rlatm
+      use addfld_module,only: addfld
 !
 ! Args:
       integer,intent(in) ::
@@ -1109,18 +981,18 @@
      |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
 !
 ! Input fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(in) ::
      |  op,         ! O+ ion
      |  optm1       ! O+ at time n-1
 !
 ! Output fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(inout) ::
      |  opout     ! O+ output for next timestep
 !
 ! Output fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(out) ::
      |  optm1out  ! O+ output for time n-1
 !
@@ -1130,46 +1002,16 @@
 ! For O+ "smooth floor". The floor is a
 ! spatial gaussian based on the O+ minimum (opmin below).
 !
-! 1/21/16 btf: O+ minimum increased from 1000 to 3000.
+! 1/21/16 btf: Increased O+ minimum.
 ! (This alleviates numerical instability that can develop
 !  near the equator at the top of the model in some cases,
 !  e.g., it allows the 2.5-deg June solstice solar max
 !  benchmark to run with step=30 rather than step=20, and
 !  may improve stability in other cases as well.)
-      real :: opmin
 !
-! Time smoothing:
-!
-! optm1out(k,i,lat): New O+ at current latitude and time n-1.
-! op(k,i,lat)      : O+ at current latitude and time.
-! optm1(k,i,lat)   : O+ at current latitude and time n-1.
-! opout(k,i,lat)   : New O+ at current latitude and time.
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            optm1out(k,i,lat) = dtsmooth*op(k,i,lat)+
-     |        dtsmooth_div2*(optm1(k,i,lat)+opout(k,i,lat))
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
-!
-! Upper boundary:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          opout(lev1,i,lat) = 0.
-          optm1out(lev1,i,lat) = 0.
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
-!
-! Ensure global non-negative O+:
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
-            if (opout(k,i,lat)    < 0.) opout(k,i,lat)    = 0.
-            if (optm1out(k,i,lat) < 0.) optm1out(k,i,lat) = 0.
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-      enddo ! lat=lat0,lat1
+! 2024/08 Haonan Wu: opmin is determined from input parameters
+! OPFLOOR, OPRATE, OPLEV, and OPLATWIDTH to be more flexible
+      real(rp) :: opmin
 !
 ! 12/4/14 btf: Enforce O+ minimum.
 ! Opfloor is Stan's "smooth floor" (product of two Gaussians,
@@ -1179,33 +1021,54 @@
 !   Change the altitude distribution of O+ minimum from Gaussian to logistic,
 !   also change the latitude distribution based on magnetic latitudes
 !   instead of geographic latitudes
-      if (opfloor/=0. .and. oprate/=0. .and.
-     |    oplev/=spval .and. oplatwidth/=0.) then
+      if (opfloor/=0. .and.
+     |    oprate/=0. .and.
+     |    oplev/=spval .and.
+     |    oplatwidth/=0.) then
         do lat=lat0,lat1
           do i=lon0,lon1
-            do k=lev0,lev1-1
+            do k=lev0,lev1
               opmin = opfloor*exp(-(rlatm(i,lat)*rtd/oplatwidth)**2)/
      |          (1+exp(-oprate*(zpmid(k)-oplev)))
-              if (opout(k,i,lat) < opmin) then
-                opout(k,i,lat) = opmin
-              endif ! opout < opmin
-            enddo ! k=lev0,lev1-1
+              if (opout(k,i,lat) < opmin) opout(k,i,lat) = opmin
+            enddo ! k=lev0,lev1
           enddo ! i=lon0,lon1
         enddo ! lat=lat0,lat1
       endif
 !
+      do lat=lat0,lat1
+        do i=lon0,lon1
+          do k=lev0,lev1
+!
+! Ensure global non-negative O+:
+! This should already been satisfied if O+ minimum is applied above
+            if (opout(k,i,lat) < 0.) opout(k,i,lat) = 0.
+!
+! Time smoothing:
+!
+! optm1out(k,i,lat): New O+ at current latitude and time n-1.
+! op(k,i,lat)      : O+ at current latitude and time.
+! optm1(k,i,lat)   : O+ at current latitude and time n-1.
+! opout(k,i,lat)   : New O+ at current latitude and time.
+            optm1out(k,i,lat) = dtsmooth*op(k,i,lat)+
+     |        dtsmooth_div2*(optm1(k,i,lat)+opout(k,i,lat))
+          enddo ! k=lev0,lev1
+        enddo ! i=lon0,lon1
+      enddo ! lat=lat0,lat1
+!
 ! Save outputs on secondary history for diagnostics:
 !     do lat=lat0,lat1
-!       call addfld('OPOUT',' ',' ',opout(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('OPOUTM1',' ',' ',
-!    |    optm1out(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+!       call addfld('OPOUT',' ',' ',opout(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('OPOUTM1',' ',' ',optm1out(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
 !     enddo ! lat=lat0,lat1
 !
       end subroutine post_oplus
 !-----------------------------------------------------------------------
       subroutine bdotdh(phij,ans,lev0,lev1,lon0,lon1,lat0,lat1)
+!
+      use params_module,only: rp
       use cons_module,only: re,dphi,dlamda,cs
       use magfield_module,only: bx,by
 !
@@ -1213,25 +1076,29 @@
 !
 ! Args:
       integer,intent(in) :: lev0,lev1,lon0,lon1,lat0,lat1
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(in) :: phij
-      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1),intent(out) :: ans
+      real(rp),dimension(lev0:lev1,lon0:lon1,lat0:lat1),intent(out) ::
+     |  ans
 !
 ! Local:
       integer :: k,i,lat
-      real :: dphidx,dphidy
+      real(rp),dimension(lev0:lev1,lon0:lon1,lat0:lat1) :: dphidx,dphidy
 !
 ! Note phij longitude dimension is lon0-2:lon1+2 (only i-1 and i+1 are used).
 ! Boundary longitudes i-1 and i+1 must have been set before this routine is
 ! called (e.g., call mp_bndlons_f3d).
       do lat=lat0,lat1
         do i=lon0,lon1
-          do k=lev0,lev1-1
-            dphidx = (phij(k,i+1,lat)-phij(k,i-1,lat))/(2.*dlamda)
-            dphidy = (phij(k,i,lat+1)-phij(k,i,lat-1))/(2.*dphi)
-            ans(k,i,lat) = 1./re*
-     |        (bx(i,lat)*dphidx/cs(lat)+by(i,lat)*dphidy)
-          enddo ! k=lev0,lev1-1
+          do k=lev0,lev1
+            dphidx(k,i,lat) =
+     |        (phij(k,i+1,lat)-phij(k,i-1,lat))/(2.*dlamda)
+            dphidy(k,i,lat) =
+     |        (phij(k,i,lat+1)-phij(k,i,lat-1))/(2.*dphi)
+            ans(k,i,lat) =
+     |        (bx(i,lat)*dphidx(k,i,lat)/cs(lat)+
+     |         by(i,lat)*dphidy(k,i,lat))/re
+          enddo ! k=lev0,lev1
         enddo ! i=lon0,lon1
       enddo ! lat=lat0,lat1
 !
@@ -1247,7 +1114,8 @@
 ! Post-processing diagnostic term analysis.
 ! This is called only at the last sub-cycling step
 !
-      use cons_module,only: dtx2inv
+      use params_module,only: rp
+      use cons_module,only: rmass_op,dtx2inv
       use input_module,only: nstep_sub
       use magfield_module,only: dipmag,sndec,csdec
       use addfld_module,only: addfld
@@ -1259,47 +1127,43 @@
      |  lat0,lat1  ! first,last latitude  indices for current task (S->N)
 !
 ! Input fields (full 3d task subdomain):
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(in) ::
      |  xnmbar,diffj,
-     |  opout,         ! O+ output for next timestep
+     |  opout,        ! O+ output for next timestep
      |  optm1_smooth, ! op at time n-1, with shapiro smoother (was s1)
      |  op_prod,op_loss,
      |  diffexp,diffp,diffq,diffr,
      |  vdotn_h,driftp,driftq,driftr,
      |  bdotdh_bvel,windp,windq,windr
 !
-      real,dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
+      real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2),
      |  intent(out) :: Fe,Fn
 !
 ! Local:
       integer :: k,i,lat
-      real :: wd
-      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
-     |  dopdt,op_loss_out,diffsum,driftsum,windsum
+      real(rp),dimension(lon0:lon1,lat0:lat1) :: proj_e,proj_n
+      real(rp),dimension(lev0:lev1,lon0:lon1,lat0:lat1) ::
+     |  wd,dopdt,op_loss_out,diffsum,driftsum,windsum
 !
       do lat=lat0,lat1
         do i=lon0,lon1
-          do k=lev0,lev1-1
-            wd = 16*3.53*1.42E6/xnmbar(k,i,lat)*diffj(k,i,lat)*
-     |        sin(dipmag(i,lat))*cos(dipmag(i,lat))
-            Fe(k,i,lat) = wd*sndec(i,lat)
-            Fn(k,i,lat) = wd*csdec(i,lat)
-          enddo ! k=lev0,lev1-1
-        enddo ! i=lon0,lon1
-!       call addfld('PARDRAG_U','','',Fe(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-!       call addfld('PARDRAG_V','','',Fn(lev0:lev1-1,lon0:lon1,lat),
-!    |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
-      enddo ! lat=lat0,lat1
+          proj_e(i,lat) =
+     |      sin(dipmag(i,lat))*cos(dipmag(i,lat))*sndec(i,lat)
+          proj_n(i,lat) =
+     |      sin(dipmag(i,lat))*cos(dipmag(i,lat))*csdec(i,lat)
 !
-      do lat=lat0,lat1
-        do i=lon0,lon1
-          do k=lev0,lev1-1
+          do k=lev0,lev1
+            wd(k,i,lat) = 3.53*1.42E6*rmass_op/
+     |        xnmbar(k,i,lat)*diffj(k,i,lat)
+            Fe(k,i,lat) = wd(k,i,lat)*proj_e(i,lat)
+            Fn(k,i,lat) = wd(k,i,lat)*proj_n(i,lat)
+!
             dopdt(k,i,lat) = dtx2inv*nstep_sub*
      |        (opout(k,i,lat)-optm1_smooth(k,i,lat))
             op_loss_out(k,i,lat) = op_loss(k,i,lat)*opout(k,i,lat)
-          enddo ! k=lev0,lev1-1
+          enddo ! k=lev0,lev1
+!
           do k=lev0+1,lev1-1
             diffsum (k,i,lat) = diffexp(k,i,lat)+
      |        diffp (k,i,lat)*opout(k-1,i,lat)+
@@ -1315,15 +1179,17 @@
      |        windr (k,i,lat)*opout(k+1,i,lat)
           enddo ! k=lev0+1,lev1-1
         enddo ! i=lon0,lon1
+!
+!       call addfld('PARDRAG_U','','',Fe(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
+!       call addfld('PARDRAG_V','','',Fn(:,lon0:lon1,lat),
+!    |    'lev',lev0,lev1,'lon',lon0,lon1,lat)
         call addfld('DOPDT','O+ changing rate','cm-3s-1',
-     |    dopdt(lev0:lev1-1,:,lat),
-     |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+     |    dopdt(:,:,lat),'lev',lev0,lev1,'lon',lon0,lon1,lat)
         call addfld('OP_PROD','O+ production','cm-3s-1',
-     |    op_prod(lev0:lev1-1,lon0:lon1,lat),
-     |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+     |    op_prod(:,lon0:lon1,lat),'lev',lev0,lev1,'lon',lon0,lon1,lat)
         call addfld('OP_LOSS','O+ loss','cm-3s-1',
-     |    -op_loss_out(lev0:lev1-1,:,lat),
-     |    'lev',lev0,lev1-1,'lon',lon0,lon1,lat)
+     |    -op_loss_out(:,:,lat),'lev',lev0,lev1,'lon',lon0,lon1,lat)
         call addfld('OP_DIFF',
      |    'O+ transport due to ambipolar diffusion','cm-3s-1',
      |    diffsum(lev0+1:lev1-1,:,lat),
@@ -1342,22 +1208,21 @@
 !-----------------------------------------------------------------------
       subroutine filter_op(opout,lev0,lev1,lon0,lon1,lat0,lat1,name)
 !
-! Filter updated O+. This is called from outside latitude loop,
-! i.e., once per timestep.
+! Filter updated O+. This is called once per timestep.
 !
-      use params_module,only: nlonp4
+      use params_module,only: nlonp4,rp
       use mpi_module,only: mytidi,mp_gatherlons_f3d,mp_scatterlons_f3d
 !
 ! Args:
       integer,intent(in) :: lev0,lev1,lon0,lon1,lat0,lat1
-      real,dimension(lev0:lev1,lon0:lon1,lat0:lat1),intent(inout) ::
+      real(rp),dimension(lev0:lev1,lon0:lon1,lat0:lat1),intent(inout) ::
      |  opout
       character(len=*),intent(in) :: name
 !
 ! Local:
       integer :: k,i,lat,ier
-      real,dimension(nlonp4,lev0:lev1) :: op_ik
-      real,dimension(lev0:lev1,nlonp4,lat0:lat1) :: op_kij
+      real(rp),dimension(nlonp4,lev0:lev1) :: op_ik
+      real(rp),dimension(lev0:lev1,nlonp4,lat0:lat1) :: op_kij
 !
 #ifdef VT
 !     code = 124 ; state = 'filter_op' ; activity='Filtering'


### PR DESCRIPTION
The oplus module is rewritten to split the calculation independent of O+ sub-cycling. This may help speed up the model when there are a lot of O+ sub-cycling.