### PR TITLE
New reaction rate for NO chemistry

### DIFF
--- a/src/chemrates.F
+++ b/src/chemrates.F
@@ -44,7 +44,7 @@
      |  rk27  = 7.7E-5,
 !
 ! Neutral chemistry:
-     |  beta2 = 5.0E-12,  ! N2D + O2 -> NO  + O1D + 1.84 eV
+!     |  beta2 = 5.0E-12,  ! N2D + O2 -> NO  + O1D + 1.84 eV
      |  beta4 = 7.0E-13,  ! N2D + O  -> N4S + O   + 2.38 eV
      |  beta6 = 7.0E-11,  ! N2D + NO -> N2  + O   + 5.63 eV
      |  beta7 = 1.06E-5   ! N2D      -> N4S + hv
@@ -66,6 +66,7 @@
 !
 ! Neutral chemistry:
      |  beta1, ! N4S + O2 -> NO  + O + 1.4  eV
+     |  beta2, ! N2D + O2 -> NO  + O1D + 1.84 eV
      |  beta3, ! N4S + NO -> N2  + O + 3.25 eV
      |  beta5, ! N2D + e  -> N4S + e + 2.38 eV
      |  beta8, ! NO  + hv -> N4S + O
@@ -113,6 +114,9 @@
       allocate(beta1(nlevp1,lon0:lon1,lat0:lat1),stat=istat)
       if (istat /= 0) write(6,"('>>> alloc_tdep: error allocating',
      |  ' beta1: stat=',i3)") istat
+      allocate(beta2(nlevp1,lon0:lon1,lat0:lat1),stat=istat)
+      if (istat /= 0) write(6,"('>>> alloc_tdep: error allocating',
+     |  ' beta2: stat=',i3)") istat
       allocate(beta3(nlevp1,lon0:lon1,lat0:lat1),stat=istat)
       if (istat /= 0) write(6,"('>>> alloc_tdep: error allocating',
      |  ' beta3: stat=',i3)") istat
@@ -158,7 +162,7 @@
 !
 ! Calculate temperature-dependent reaction rates (called at each latitude)
 !
-      use input_module,only: f107  ! 10.7 cm flux (from input and/or gpi)
+      use input_module,only: duff,f107  ! 10.7 cm flux (from input and/or gpi)
       use init_module,only: sfeps  ! flux variation from orbital excentricity
       use cons_module,only: check_exp
 !
@@ -252,6 +256,13 @@
 !
 ! beta1: N4S + O2 -> NO  + O + 1.4  eV
           beta1(k,i,lat) = 1.5E-11*exp(-3600./tn(k,i))
+!
+! New reaction rate from Duff et al. (2003), suggested by Sheng et al. (2017)
+          if (duff) then
+            beta2(k,i,lat) = 6.2e-12*tn(k,i)/300.
+          else
+            beta2(k,i,lat) = 5e-12
+          endif
 !
 ! beta3: N4S + NO -> N2  + O + 3.25 eV
           beta3(k,i,lat) =3.4e-11*sqrt(tn(k,i)/300.)

--- a/src/comp_n2d.F
+++ b/src/comp_n2d.F
@@ -108,7 +108,7 @@
         n2d_lbc(i,3,lat) = -rmass_n2d/xnmbari(lev0,i)*
      |    qtef(lev0,i,lat)*brn2d/
      |    (xnmbari(lev0,i)*
-     |    (beta2*o2(lev0,i)*rmassinv_o2+
+     |    (beta2(lev0,i,lat)*o2(lev0,i)*rmassinv_o2+
      |     beta4*o1(lev0,i)*rmassinv_o1+
      |     beta6*no(lev0,i)*rmassinv_no)+
      |     beta7+beta5(lev0,i,lat)*ne(lev0,i))
@@ -127,7 +127,7 @@
 !
 ! Total loss of N2D:
           n2d_loss(k,i,lat) = -(xnmbar(k,i)*
-     |      (beta2*o2(k,i)*rmassinv_o2+
+     |      (beta2(k,i,lat)*o2(k,i)*rmassinv_o2+
      |       beta4*o1(k,i)*rmassinv_o1+
      |       beta6*no(k,i)*rmassinv_no)+
      |       beta7+beta5(k,i,lat)*sqrt(ne(k,i)*ne(k+1,i))+

--- a/src/comp_no.F
+++ b/src/comp_no.F
@@ -104,8 +104,8 @@
         do k=lev0,lev1-1
 !
           no_prod(k,i,lat) = xnmbar(k,i)**2*o2(k,i)*rmassinv_o2*
-     |      (beta1(k,i,lat)*n4s(k,i)*rmassinv_n4s+beta2*n2d(k,i)*
-     |      rmassinv_n2d)
+     |      (beta1(k,i,lat)*n4s(k,i)*rmassinv_n4s+
+     |       beta2(k,i,lat)*n2d(k,i)*rmassinv_n2d)
 !
           no_prod(k,i,lat) = no_prod(k,i,lat)+xnmbar(k,i)**3*
      |      beta17(k,i,lat)*o1(k,i)*rmassinv_o1*n2(k,i)*

--- a/src/comp_o2o.F
+++ b/src/comp_o2o.F
@@ -94,7 +94,7 @@
      |      sqrt(ne(k,i)*ne(k+1,i))
 ! s2
           pox2(k,i) = xnmbar(k,i)*(beta1(k,i,lat)*n4s(k,i)/rmass_n4s+
-     |      beta2*n2d(k,i)/rmass_n2d)+rk1(k,i,lat)*op(k,i)+rk7*
+     |      beta2(k,i,lat)*n2d(k,i)/rmass_n2d)+rk1(k,i,lat)*op(k,i)+rk7*
      |      nplus(k,i)+2.*rji(k,i)
 !
 ! OX loss:
@@ -110,8 +110,8 @@
 !
 ! O2 loss:
           lo21(k,i) = xnmbar(k,i)*(beta1(k,i,lat)*n4s(k,i)/rmass_n4s+
-     |      beta2*n2d(k,i)/rmass_n2d)+rk1(k,i,lat)*op(k,i)+(rk6+rk7)*
-     |      nplus(k,i)+rk9*n2p(k,i)+rji(k,i)
+     |      beta2(k,i,lat)*n2d(k,i)/rmass_n2d)+rk1(k,i,lat)*op(k,i)+
+     |      (rk6+rk7)*nplus(k,i)+rk9*n2p(k,i)+rji(k,i)
 !
           lo22(k,i) = qo2pi(k,i)
 !

--- a/src/input.F
+++ b/src/input.F
@@ -102,7 +102,8 @@
      |  et,              ! logical to calculate electron turbulent heating
      |  saps,            ! logical to include empirical SAPS
      |  doEclipse,       ! logical to do eclipse mask or not
-     |  oneway           ! logical to use oneway mix reader
+     |  oneway,          ! logical to use oneway mix reader
+     |  duff             ! logical to choose reaction rate for N(2D)+O2->NO+O
 !
 ! Parameters as read from namelist:
       real(rp) :: rd_power,rd_ctpoten,rd_f107,rd_f107a,rd_bximf,
@@ -200,7 +201,7 @@
      |  kp_time,al_time,swden_time,swvel_time,indices_interp,
      |  imf_ncfile,saber_ncfile,tidi_ncfile,sech_nbyte,f107_time,
      |  f107a_time,hpss_path,current_pg,current_kq,calc_helium,
-     |  bgrddata_ncfile,ctmt_ncfile,electron_heating,
+     |  bgrddata_ncfile,ctmt_ncfile,electron_heating,duff,
      |  amienh,amiesh,amie_ibkg,he_coefs_ncfile,enforce_n2,et,saps,
      |  subaur_data,doEclipse,eclipse_list,oneway,mixfile,
      |  nudge_ncpre,nudge_ncfile,nudge_ncpost,nudge_flds,
@@ -322,6 +323,7 @@
       saps = .false.
       doEclipse = .false.
       oneway = .false.
+      duff = .false.
 
       opdiffcap = spval
       opdiffrate = spval

--- a/src/qjnno.F
+++ b/src/qjnno.F
@@ -37,7 +37,7 @@
      |      evergs*avo*xnmbar(k,i)*(n4s(k,i)*rmassinv_n4s*
      |      (beta1(k,i,lat)*o2(k,i)*rmassinv_o2*1.4+
      |       beta3(k,i,lat)*no(k,i)*rmassinv_no*2.68)+
-     |      n2d(k,i)*rmassinv_n2d*(beta2*o2(k,i)*rmassinv_o2* 
+     |      n2d(k,i)*rmassinv_n2d*(beta2(k,i,lat)*o2(k,i)*rmassinv_o2*
      |      1.84+beta4*o1(k,i)*rmassinv_o1*
      |      2.38+beta5(k,i,lat)*.5*(ne(k,i)+ne(k+1,i))*2.38/
      |      xnmbar(k,i)+beta6*no(k,i)*rmassinv_no*5.63))


### PR DESCRIPTION
Duff et al. (2003) formula is now implemented as suggested by Sheng et al. (2017). A new input parameter "duff" is introduced to switch between the new rate (6.2e-12*tn/300, temperature dependent) and the old rate (5e-12, constant). Default is off (using the old constant reaction rate).