### PR TITLE
Abort criterion oplus

### DIFF
--- a/src/lamdas.F
+++ b/src/lamdas.F
@@ -70,7 +70,7 @@
      |  nu_nop_o2 = 4.27E-10, ! NO+ ~ O2
      |  nu_o2p_o  = 2.31E-10, ! O2+ ~ O
      |  nu_np_o   = 4.42E-10, ! N+  ~ O
-     |  nu_n2p_o  = 4.42E-10, ! N2+ ~ O
+     |  nu_n2p_o  = 2.58E-10, ! N2+ ~ O
      |  nu_nop_o  = 2.44E-10, ! NO+ ~ O
      |  nu_o2p_he = 0.70E-10, ! O2+ ~ He
      |  nu_op_he  = 1.32E-10, ! O+  ~ He

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -30,11 +30,10 @@
 !
       use params_module,only: rp
       use input_module,only: nstep_sub
-      use mpi_module,only: mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
-     |   ,TIEGCM_WORLD
+      use mpi_module,only: TIEGCM_WORLD,handle_mpi_err,
+     |  mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
       use addfld_module,only: addfld
-
-      use mpi_f08
+      use mpi
 !
 ! Args:
       integer,intent(in) ::
@@ -65,7 +64,7 @@
      |  xiop2p,xiop2d,Fe,Fn
 !
 ! Local:
-      integer :: k,i,lat,nlevs,istep
+      integer :: k,i,lat,nlevs,istep,ierror
       real(rp),dimension(lon0-2:lon1+2,lat0-2:lat1+2) ::
      |  dvb,ubcrhs,lbcrhs
       real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
@@ -77,9 +76,6 @@
       real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) ::
      |  tmpf3d
       real(rp) :: delta
-      real(rp), dimension(lev0+1:lev1-1,lon0:lon1,lat0:lat1) ::
-     | op_prev
-      integer:: ierror
       real(rp), parameter :: eps = 100 ! cm-3
 !
 ! Number of pressure levels (this will equal nlevp1):
@@ -96,10 +92,7 @@
       op_sub = op
       optm1_sub = optm1
 !
-        istep = 1
-        delta = huge(delta)
-        do while(delta>eps)
-!
+      do istep=1,nstep_sub
         call smooth_oplus(optm1_sub,optm1_smooth,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
@@ -128,52 +121,38 @@
         call post_oplus(op_sub,optm1_sub,opout_sub,optm1out_sub,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
-
         tmpf3d(lev0:lev1,lon0:lon1,lat0:lat1,1) =
-     |   opout_sub(lev0:lev1,lon0:lon1,lat0:lat1)
+     |    opout_sub(lev0:lev1,lon0:lon1,lat0:lat1)
         tmpf3d(lev0:lev1,lon0:lon1,lat0:lat1,2) =
-     |   optm1out_sub(lev0:lev1,lon0:lon1,lat0:lat1)
-
+     |    optm1out_sub(lev0:lev1,lon0:lon1,lat0:lat1)
+!
         call mp_polelats_f3d(tmpf3d(:,lon0:lon1,:,:),
      |    lev0,lev1,lon0,lon1,lat0,lat1,2,(/1.,1./))
         call mp_bndlats_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2)
         call mp_bndlons_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2,0)
-
+!
         opout_sub = tmpf3d(:,:,:,1)
         optm1out_sub = tmpf3d(:,:,:,2)
-
-        if(istep>1)then
-          ! ignore lowest and uppermost layer
-          ! TODO also compute max for op_nm?
-          delta = maxval(abs(
-     |            opout_sub(lev0+1:lev1-1,lon0:lon1,lat0:lat1)-op_prev
-     |            ))
-
-        call MPI_Allreduce(delta, delta, 1, MPI_REAL8,
-     |                   MPI_Max, TIEGCM_WORLD, ierror)
-!           write(*,*) 'step: ', istep, ' delta: ', delta
-        end if
-
-        op_prev = opout_sub(lev0+1:lev1-1,lon0:lon1,lat0:lat1)
+!
+! ignore the uppermost layer since it is extrapolated
+        delta = maxval(abs(
+     |    opout_sub(lev0:lev1-1,lon0:lon1,lat0:lat1)-
+     |    op_sub   (lev0:lev1-1,lon0:lon1,lat0:lat1)))
+!
+        call MPI_Allreduce(MPI_IN_PLACE, delta, 1, MPI_REAL8,
+     |                     MPI_MAX, TIEGCM_WORLD, ierror)
+        if (ierror /= 0)
+     |    call handle_mpi_err(ierror,'oplus call MPI_Allreduce')
+!
+! exit loop if it already converges
+        if (delta < eps) exit
 !
         op_sub = opout_sub
         optm1_sub = optm1out_sub
-!
-        if (istep > nstep_sub ) then
-          write(*,*) "WARNING oplus maximum number of iteration ",
-     |               "reached and break condition is not satisifed ",
-     |               "maximal error is ", delta, " cm-3"
-
-        exit
-        end if
-        istep = istep + 1
-
-
       enddo ! istep=1,nstep_sub
-
+!
       opout = opout_sub
-      optm1out= optm1out_sub
-
+      optm1out = optm1out_sub
 !
       end subroutine oplus
 !-----------------------------------------------------------------------

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -77,7 +77,9 @@
      |  tmpf3d
       real(rp),dimension(lev0:lev1-1,lon0:lon1,lat0:lat1) :: err
       real(rp),dimension(2) :: delta
-      real(rp),dimension(2),parameter :: eps = (/100.0_rp,1e-2/) ! cm-3, %
+      real(rp),dimension(2),parameter :: eps = (/100.0_rp,0.01/) ! cm-3,- %
+      integer :: stop_at_iteration
+
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
@@ -93,6 +95,7 @@
       op_sub = op
       optm1_sub = optm1
 !
+      stop_at_iteration = nstep_sub
       do istep=1,nstep_sub
         call smooth_oplus(optm1_sub,optm1_smooth,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
@@ -102,12 +105,14 @@
      |    op_sub,opout_sub,diffj,diffexp,vdotn_h,bdotdh_bvel,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
+      if(istep==stop_at_iteration) then
         call calc_terms(xnmbar,diffj,Fe,Fn,
      |    opout_sub,optm1_smooth,op_prod,op_loss,
      |    diffexp,diffp,diffq,diffr,
      |    vdotn_h,driftp,driftq,driftr,
      |    bdotdh_bvel,windp,windq,windr,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
+      end if
 !
 ! Filter updated O+:
         call filter_op(opout_sub(:,lon0:lon1,lat0:lat1),
@@ -121,6 +126,7 @@
         call post_oplus(op_sub,optm1_sub,opout_sub,optm1out_sub,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
+! stack optm1out_sub and opout_sub for calling mp_* functions
         tmpf3d(lev0:lev1,lon0:lon1,lat0:lat1,1) =
      |    opout_sub(lev0:lev1,lon0:lon1,lat0:lat1)
         tmpf3d(lev0:lev1,lon0:lon1,lat0:lat1,2) =
@@ -134,23 +140,28 @@
         opout_sub = tmpf3d(:,:,:,1)
         optm1out_sub = tmpf3d(:,:,:,2)
 !
+! calculate abort criterion only every 25 iterations to reduce
+! costs introduced by additional communication
+        if(modulo(istep,25) == 0) then
 ! ignore the uppermost layer since it is extrapolated
-        err = abs(
-     |    opout_sub(lev0:lev1-1,lon0:lon1,lat0:lat1)-
-     |    op_sub   (lev0:lev1-1,lon0:lon1,lat0:lat1))
-        delta(1) = maxval(err)
+          err = abs(
+     |      opout_sub(lev0:lev1-1,lon0:lon1,lat0:lat1)-
+     |      op_sub   (lev0:lev1-1,lon0:lon1,lat0:lat1))
+          delta(1) = maxval(err)
 !
 ! put a floor on the denominator to avoid dividing by zero
-        delta(2) = maxval(err/
-     |    max(op_sub(lev0:lev1-1,lon0:lon1,lat0:lat1),1e-6_rp))
+          delta(2) = maxval(err/
+     |      max(op_sub(lev0:lev1-1,lon0:lon1,lat0:lat1),1e-6_rp))
 !
-        call MPI_Allreduce(MPI_IN_PLACE, delta, 2, MPI_REAL8,
-     |                     MPI_MAX, TIEGCM_WORLD, ierror)
-        if (ierror /= 0)
-     |    call handle_mpi_err(ierror,'oplus call MPI_Allreduce')
-!
-! exit loop if it already converges
-        if (all(delta < eps)) exit
+          call MPI_Allreduce(MPI_IN_PLACE, delta, 2, MPI_REAL8,
+     |                       MPI_MAX, TIEGCM_WORLD, ierror)
+          if (ierror /= 0)
+     |      call handle_mpi_err(ierror,'oplus call MPI_Allreduce')
+
+          if (all(delta < eps)) stop_at_iteration = istep+1
+        end if
+
+        if(istep==stop_at_iteration) exit
 !
         op_sub = opout_sub
         optm1_sub = optm1out_sub

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -102,8 +102,7 @@
      |    op_sub,opout_sub,diffj,diffexp,vdotn_h,bdotdh_bvel,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
-        if (istep == nstep_sub)
-     |    call calc_terms(xnmbar,diffj,Fe,Fn,
+        call calc_terms(xnmbar,diffj,Fe,Fn,
      |    opout_sub,optm1_smooth,op_prod,op_loss,
      |    diffexp,diffp,diffq,diffr,
      |    vdotn_h,driftp,driftq,driftr,

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -64,7 +64,7 @@
      |  xiop2p,xiop2d,Fe,Fn
 !
 ! Local:
-      integer :: k,i,lat,nlevs,istep,ierror
+      integer :: nlevs,istep,ierror
       real(rp),dimension(lon0-2:lon1+2,lat0-2:lat1+2) ::
      |  dvb,ubcrhs,lbcrhs
       real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2) ::
@@ -75,8 +75,9 @@
      |  diffj,diffexp,vdotn_h,bdotdh_bvel
       real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) ::
      |  tmpf3d
-      real(rp) :: delta
-      real(rp), parameter :: eps = 100 ! cm-3
+      real(rp),dimension(lev0:lev1-1,lon0:lon1,lat0:lat1) :: err
+      real(rp),dimension(2) :: delta
+      real(rp),dimension(2),parameter :: eps = (/100.0_rp,1e-2/) ! cm-3, %
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
@@ -135,17 +136,22 @@
         optm1out_sub = tmpf3d(:,:,:,2)
 !
 ! ignore the uppermost layer since it is extrapolated
-        delta = maxval(abs(
+        err = abs(
      |    opout_sub(lev0:lev1-1,lon0:lon1,lat0:lat1)-
-     |    op_sub   (lev0:lev1-1,lon0:lon1,lat0:lat1)))
+     |    op_sub   (lev0:lev1-1,lon0:lon1,lat0:lat1))
+        delta(1) = maxval(err)
 !
-        call MPI_Allreduce(MPI_IN_PLACE, delta, 1, MPI_REAL8,
+! put a floor on the denominator to avoid dividing by zero
+        delta(2) = maxval(err/
+     |    max(op_sub(lev0:lev1-1,lon0:lon1,lat0:lat1),1e-6_rp))
+!
+        call MPI_Allreduce(MPI_IN_PLACE, delta, 2, MPI_REAL8,
      |                     MPI_MAX, TIEGCM_WORLD, ierror)
         if (ierror /= 0)
      |    call handle_mpi_err(ierror,'oplus call MPI_Allreduce')
 !
 ! exit loop if it already converges
-        if (delta < eps) exit
+        if (all(delta < eps)) exit
 !
         op_sub = opout_sub
         optm1_sub = optm1out_sub

--- a/src/oplus.F
+++ b/src/oplus.F
@@ -31,7 +31,10 @@
       use params_module,only: rp
       use input_module,only: nstep_sub
       use mpi_module,only: mp_polelats_f3d,mp_bndlats_f3d,mp_bndlons_f3d
+     |   ,TIEGCM_WORLD
       use addfld_module,only: addfld
+
+      use mpi_f08
 !
 ! Args:
       integer,intent(in) ::
@@ -73,6 +76,11 @@
      |  diffj,diffexp,vdotn_h,bdotdh_bvel
       real(rp),dimension(lev0:lev1,lon0-2:lon1+2,lat0-2:lat1+2,2) ::
      |  tmpf3d
+      real(rp) :: delta
+      real(rp), dimension(lev0+1:lev1-1,lon0:lon1,lat0:lat1) ::
+     | op_prev
+      integer:: ierror
+      real(rp), parameter :: eps = 100 ! cm-3
 !
 ! Number of pressure levels (this will equal nlevp1):
       nlevs = lev1-lev0+1 ! for bndlons calls
@@ -85,16 +93,13 @@
      |  p_coeff,q_coeff,r_coeff,
      |  lev0,lev1,lon0,lon1,lat0,lat1)
 !
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
-          do k=lev0,lev1
-            op_sub(k,i,lat) = op(k,i,lat)
-            optm1_sub(k,i,lat) = optm1(k,i,lat)
-          enddo ! k=lev0,lev1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
+      op_sub = op
+      optm1_sub = optm1
 !
-      do istep=1,nstep_sub
+        istep = 1
+        delta = huge(delta)
+        do while(delta>eps)
+!
         call smooth_oplus(optm1_sub,optm1_smooth,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
@@ -123,45 +128,52 @@
         call post_oplus(op_sub,optm1_sub,opout_sub,optm1out_sub,
      |    lev0,lev1,lon0,lon1,lat0,lat1)
 !
-        do lat=lat0,lat1
-          do i=lon0,lon1
-            do k=lev0,lev1
-              tmpf3d(k,i,lat,1) = opout_sub(k,i,lat)
-              tmpf3d(k,i,lat,2) = optm1out_sub(k,i,lat)
-            enddo ! k=lev0,lev1
-          enddo ! i=lon0,lon1
-        enddo ! lat=lat0,lat1
+
+        tmpf3d(lev0:lev1,lon0:lon1,lat0:lat1,1) =
+     |   opout_sub(lev0:lev1,lon0:lon1,lat0:lat1)
+        tmpf3d(lev0:lev1,lon0:lon1,lat0:lat1,2) =
+     |   optm1out_sub(lev0:lev1,lon0:lon1,lat0:lat1)
+
         call mp_polelats_f3d(tmpf3d(:,lon0:lon1,:,:),
      |    lev0,lev1,lon0,lon1,lat0,lat1,2,(/1.,1./))
         call mp_bndlats_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2)
         call mp_bndlons_f3d(tmpf3d,nlevs,lon0,lon1,lat0,lat1,2,0)
-        do lat=lat0-2,lat1+2
-          do i=lon0-2,lon1+2
-            do k=lev0,lev1
-              opout_sub(k,i,lat) = tmpf3d(k,i,lat,1)
-              optm1out_sub(k,i,lat) = tmpf3d(k,i,lat,2)
-            enddo ! k=lev0,lev1
-          enddo ! i=lon0-2,lon1+2
-        enddo ! lat=lat0-2,lat1+2
+
+        opout_sub = tmpf3d(:,:,:,1)
+        optm1out_sub = tmpf3d(:,:,:,2)
+
+        if(istep>1)then
+          ! ignore lowest and uppermost layer
+          ! TODO also compute max for op_nm?
+          delta = maxval(abs(
+     |            opout_sub(lev0+1:lev1-1,lon0:lon1,lat0:lat1)-op_prev
+     |            ))
+
+        call MPI_Allreduce(delta, delta, 1, MPI_REAL8,
+     |                   MPI_Max, TIEGCM_WORLD, ierror)
+!           write(*,*) 'step: ', istep, ' delta: ', delta
+        end if
+
+        op_prev = opout_sub(lev0+1:lev1-1,lon0:lon1,lat0:lat1)
 !
-        do lat=lat0-2,lat1+2
-          do i=lon0-2,lon1+2
-            do k=lev0,lev1
-              op_sub(k,i,lat) = opout_sub(k,i,lat)
-              optm1_sub(k,i,lat) = optm1out_sub(k,i,lat)
-            enddo ! k=lev0,lev1
-          enddo ! i=lon0-2,lon1+2
-        enddo ! lat=lat0-2,lat1+2
+        op_sub = opout_sub
+        optm1_sub = optm1out_sub
+!
+        if (istep > nstep_sub ) then
+          write(*,*) "WARNING oplus maximum number of iteration ",
+     |               "reached and break condition is not satisifed ",
+     |               "maximal error is ", delta, " cm-3"
+
+        exit
+        end if
+        istep = istep + 1
+
+
       enddo ! istep=1,nstep_sub
-!
-      do lat=lat0-2,lat1+2
-        do i=lon0-2,lon1+2
-          do k=lev0,lev1
-            opout(k,i,lat) = opout_sub(k,i,lat)
-            optm1out(k,i,lat) = optm1out_sub(k,i,lat)
-          enddo ! k=lev0,lev1
-        enddo ! i=lon0-2,lon1+2
-      enddo ! lat=lat0-2,lat1+2
+
+      opout = opout_sub
+      optm1out= optm1out_sub
+
 !
       end subroutine oplus
 !-----------------------------------------------------------------------


### PR DESCRIPTION
The current implementation uses a fixed number of iterations to update O+ number concentration. This number is controlled by the `nstep_sub`  input option. Instead, I propose to use `nstep_sub` as the maximum number of iterations and break the loop once a certain threshold/epsilon has been reached. This makes the model more versatile, as it automatically adapts the number of iterations to the current situation.